### PR TITLE
Fix installation after breaking change in servant-0.16

### DIFF
--- a/src/Telegram/Bot/API/MakingRequests.hs
+++ b/src/Telegram/Bot/API/MakingRequests.hs
@@ -28,7 +28,7 @@ defaultTelegramClientEnv token = ClientEnv
   <*> pure (botBaseUrl token)
   <*> pure Nothing
 
-defaultRunBot :: Token -> ClientM a -> IO (Either ServantError a)
+defaultRunBot :: Token -> ClientM a -> IO (Either ClientError a)
 defaultRunBot token bot = do
   env <- defaultTelegramClientEnv token
   runClientM bot env

--- a/src/Telegram/Bot/Simple/BotApp.hs
+++ b/src/Telegram/Bot/Simple/BotApp.hs
@@ -36,7 +36,7 @@ startBotAsync_ :: BotApp model action -> ClientEnv -> IO ()
 startBotAsync_ bot env = void (startBotAsync bot env)
 
 -- | Start bot with update polling in the main thread.
-startBot :: BotApp model action -> ClientEnv -> IO (Either ServantError ())
+startBot :: BotApp model action -> ClientEnv -> IO (Either ClientError ())
 startBot bot env = do
   botEnv <- startBotEnv bot env
   runClientM (startBotPolling bot botEnv) env

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2018-06-01
+resolver: lts-14.2
 packages:
   - '.'

--- a/telegram-bot-simple.cabal
+++ b/telegram-bot-simple.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.28.2.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b0f1a9c9eb60eb7bbec81ed3a356f6fbdb1c0eded979812657501e07cdebc427
+-- hash: 35836d4811270baa748cbe4854f38e1889bd220b28fe7b029ee6d3e07a6f1d7b
 
 name:           telegram-bot-simple
 version:        0.2.0
@@ -17,10 +19,9 @@ copyright:      Nickolay Kudasov
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
 extra-source-files:
-    CHANGELOG.md
     README.md
+    CHANGELOG.md
 
 source-repository head
   type: git


### PR DESCRIPTION
- Since 0.16 servant changed its API, see [changelog](http://hackage.haskell.org/package/servant-client-0.16/changelog) for more details.
- @fizruk, do we need to support backward compatibility with older versions of GHC?

Closes #18.