### PR TITLE
Define `MonadFail UpdateParser` instance for base ≥ 4.13

### DIFF
--- a/src/Telegram/Bot/Simple/UpdateParser.hs
+++ b/src/Telegram/Bot/Simple/UpdateParser.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Telegram.Bot.Simple.UpdateParser where
 
 import           Control.Applicative
@@ -26,6 +27,11 @@ instance Alternative UpdateParser where
 instance Monad UpdateParser where
   return = pure
   UpdateParser x >>= f = UpdateParser (\u -> x u >>= flip runUpdateParser u . f)
+
+#if MIN_VERSION_base(4,13,0)
+instance MonadFail UpdateParser where
+  fail = errorWithoutStackTrace
+#endif
 
 mkParser :: (Update -> Maybe a) -> UpdateParser a
 mkParser = UpdateParser

--- a/src/Telegram/Bot/Simple/UpdateParser.hs
+++ b/src/Telegram/Bot/Simple/UpdateParser.hs
@@ -30,7 +30,7 @@ instance Monad UpdateParser where
 
 #if MIN_VERSION_base(4,13,0)
 instance MonadFail UpdateParser where
-  fail = errorWithoutStackTrace
+  fail _ = empty
 #endif
 
 mkParser :: (Update -> Maybe a) -> UpdateParser a


### PR DESCRIPTION
`fail` is removed from `Monad` due to "MonadFail Proposal"

This could be more sophisticated, using `errorWithoutStackTrace` 
just to preserve the original semantics of `fail` here.

Effectively fixes building the library for Stackage LTS ≥15.