### PR TITLE
Implement sendDocument function support.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
 - aeson-pretty
 - bytestring
 - cron
+- filepath
 - hashable
 - http-api-data
 - http-client

--- a/src/Telegram/Bot/API/Methods.hs
+++ b/src/Telegram/Bot/API/Methods.hs
@@ -1,15 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 module Telegram.Bot.API.Methods where
 
+import Control.Monad.IO.Class
 import Data.Aeson
+import Data.Aeson.Text
+import Data.Bool
 import Data.Proxy
 import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
 import GHC.Generics (Generic)
 import Servant.API
 import Servant.Client hiding (Response)
+import Servant.Multipart
+import System.FilePath
 
 import Telegram.Bot.API.Internal.Utils
 import Telegram.Bot.API.MakingRequests
@@ -94,3 +104,89 @@ data SendMessageRequest = SendMessageRequest
 
 instance ToJSON   SendMessageRequest where toJSON = gtoJSON
 instance FromJSON SendMessageRequest where parseJSON = gparseJSON
+
+-- ** 'sendMessage'
+
+type SendDocumentContent
+  = "sendDocument"
+  :> MultipartForm Tmp SendDocumentRequest
+  :> Post '[JSON] (Response Message)
+
+type SendDocumentLink
+  = "sendDocument"
+  :> ReqBody '[JSON] SendDocumentRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send text messages.
+-- On success, the sent 'Message' is returned.
+--
+-- <https:\/\/core.telegram.org\/bots\/api#senddocument>
+sendDocument :: SendDocumentRequest -> ClientM (Response Message)
+sendDocument r = do
+  case sendDocumentDocument r of
+    DocumentFile{} -> do
+      boundary <- liftIO genBoundary
+      client (Proxy @SendDocumentContent) (boundary, r)
+    _ -> client (Proxy @SendDocumentLink) r
+
+-- | Request parameters for 'sendDocument'
+data SendDocumentRequest = SendDocumentRequest
+  { sendDocumentChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername@).
+  , sendDocumentDocument :: DocumentFile -- ^ Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data
+  , sendDocumentThumb :: Maybe FilePath -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>
+  , sendDocumentCaption :: Maybe Text -- ^ Document caption (may also be used when resending documents by file_id), 0-1024 characters after entities parsing
+  , sendDocumentParseMode :: Maybe ParseMode -- ^ Mode for parsing entities in the document caption.
+  , sendDocumentDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendDocumentReplyToMessageId :: Maybe MessageId
+  , sendDocumentReplyMarkup :: Maybe SomeReplyMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+data DocumentFile
+  = DocumentFileId Int
+  | DocumentUrl Text
+  | DocumentFile FilePath ContentType
+
+instance ToJSON DocumentFile where
+  toJSON (DocumentFileId i) = toJSON (show i)
+  toJSON (DocumentUrl t) = toJSON t
+  toJSON (DocumentFile f _) = toJSON ("attach://" <> T.pack (takeFileName f))
+
+type ContentType = Text
+
+instance ToMultipart Tmp SendDocumentRequest where
+  toMultipart SendDocumentRequest{..} = MultipartData fields files where
+    fields = 
+      [ Input "document" $ T.pack $ "attach://file"
+      , Input "chat_id" $ case sendDocumentChatId of
+          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
+          SomeChatUsername txt -> txt
+      ] <> 
+      (   (maybe id (\_ -> ((Input "thumb" "attach://thumb"):)) sendDocumentThumb)
+        $ (maybe id (\t -> ((Input "caption" t):)) sendDocumentCaption)
+        $ (maybe id (\t -> ((Input "parse_mode" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentParseMode)
+        $ (maybe id (\t -> ((Input "disable_notifications" (bool "false" "true" t)):)) sendDocumentDisableNotification)
+        $ (maybe id (\t -> ((Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentReplyToMessageId)
+        $ (maybe id (\t -> ((Input "reply_markup" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentReplyMarkup)
+        [])
+    files 
+      = (FileData "file" (T.pack $ takeFileName path) ct path)
+      : maybe [] (\t -> [FileData "thumb" (T.pack $ takeFileName t) "image/jpeg" t]) sendDocumentThumb
+
+    DocumentFile path ct = sendDocumentDocument
+    
+
+instance ToJSON   SendDocumentRequest where toJSON = gtoJSON
+
+-- | Generate send document structure.
+toSendDocument :: SomeChatId -> DocumentFile -> SendDocumentRequest
+toSendDocument ch df = SendDocumentRequest
+  { sendDocumentChatId = ch
+  , sendDocumentDocument = df
+  , sendDocumentThumb = Nothing
+  , sendDocumentCaption = Nothing
+  , sendDocumentParseMode = Nothing
+  , sendDocumentDisableNotification = Nothing
+  , sendDocumentReplyToMessageId = Nothing
+  , sendDocumentReplyMarkup = Nothing
+  }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
 resolver: lts-15.8
 packages:
   - '.'
+extra-deps:
+  - servant-multipart-0.11.5@sha256:1633f715b5b53d648a1da69839bdc5046599f4f7244944d4bbf852dba38d8f4b,2319

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: servant-multipart-0.11.5@sha256:1633f715b5b53d648a1da69839bdc5046599f4f7244944d4bbf852dba38d8f4b,2319
+    pantry-tree:
+      size: 333
+      sha256: b3e1fd2ad2e654475be000c2f0ac6f717b5499436fa73eec50ceccddf352dcec
+  original:
+    hackage: servant-multipart-0.11.5@sha256:1633f715b5b53d648a1da69839bdc5046599f4f7244944d4bbf852dba38d8f4b,2319
 snapshots:
 - completed:
     size: 492015

--- a/telegram-bot-simple.cabal
+++ b/telegram-bot-simple.cabal
@@ -61,6 +61,7 @@ library
     , base >=4.9 && <5
     , bytestring
     , cron
+    , filepath
     , hashable
     , http-api-data
     , http-client
@@ -71,6 +72,7 @@ library
     , profunctors
     , servant
     , servant-client
+    , servant-multipart
     , split
     , stm
     , template-haskell


### PR DESCRIPTION
sendDocument is implemented as a special wrapper that decide
what content type to use based on the query content. Such approach
is not servant-client friendly, so we ToMultipart function becomes
partial, but it may be ok, as other solutions would require manual
copy of the types and it will be much harder to follow.

Fixes #30.

----
This commit includes patch from the other, I can exclude that as soon as it will be merged.