### PR TITLE
Add MarkdownV2 parse mode

### DIFF
--- a/src/Telegram/Bot/API/Methods.hs
+++ b/src/Telegram/Bot/API/Methods.hs
@@ -86,6 +86,7 @@ instance FromJSON SomeReplyMarkup where parseJSON = genericSomeParseJSON
 data ParseMode
   = Markdown
   | HTML
+  | MarkdownV2
   deriving (Generic)
 
 instance ToJSON   ParseMode


### PR DESCRIPTION
Telegram API supports MarkdownV2 flavour of markdown
that is much richer than V1.
See https://core.telegram.org/bots/api#markdownv2-style for details.