### PR TITLE
Derive Hashable for MessageId

### DIFF
--- a/src/Telegram/Bot/API/Types.hs
+++ b/src/Telegram/Bot/API/Types.hs
@@ -137,7 +137,7 @@ data Message = Message
 
 -- | Unique message identifier inside this chat.
 newtype MessageId = MessageId Int32
-  deriving (Eq, Show, ToJSON, FromJSON)
+  deriving (Eq, Show, ToJSON, FromJSON, Hashable)
 
 instance ToHttpApiData MessageId where toUrlPiece a = pack . show @Int32 $ coerce a
 


### PR DESCRIPTION
It is strange that Hashable is only derived for ChatId, not for MessageId, considering that MessageId definitely be Hashable.

Signed-off-by: Pavel Kalugin <paul.kalug@gmail.com>