### PR TITLE
Restrict `cron` lower boundary to fix cron jobs

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ dependencies:
 - pretty-show
 - servant
 - servant-client
+- servant-multipart
 - split
 - stm
 - template-haskell

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,4 @@ packages:
   - '.'
 extra-deps:
   - servant-multipart-0.11.5@sha256:1633f715b5b53d648a1da69839bdc5046599f4f7244944d4bbf852dba38d8f4b,2319
+  - cron-0.7.0 # See https://github.com/fizruk/telegram-bot-simple/issues/37 for more details

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,6 +11,13 @@ packages:
       sha256: b3e1fd2ad2e654475be000c2f0ac6f717b5499436fa73eec50ceccddf352dcec
   original:
     hackage: servant-multipart-0.11.5@sha256:1633f715b5b53d648a1da69839bdc5046599f4f7244944d4bbf852dba38d8f4b,2319
+- completed:
+    hackage: cron-0.7.0@sha256:2a9e5637d4ebfd8db34444d340be8bd7f1968aa8b1078cc0bc7bef47a8b5af8e,3878
+    pantry-tree:
+      size: 1680
+      sha256: bcc8ad18105b96d09caf8bb6fcbe09d69145d8486cc7c67ecafb7524a47f047f
+  original:
+    hackage: cron-0.7.0
 snapshots:
 - completed:
     size: 492015

--- a/telegram-bot-simple.cabal
+++ b/telegram-bot-simple.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 815631caa1274f24031eaa1ec3c4ea08c75d46b660a0b266eeea28b0f123c325
+-- hash: 6d52edc3fb6015df0405b5a83558655525a8de69bd624202d18729eacbb353a1
 
 name:           telegram-bot-simple
 version:        0.3.3
@@ -19,7 +19,6 @@ copyright:      Nickolay Kudasov
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-Tested-with:    GHC ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.10.1
 extra-source-files:
     README.md
     CHANGELOG.md
@@ -61,7 +60,7 @@ library
     , aeson-pretty
     , base >=4.9 && <5
     , bytestring
-    , cron
+    , cron >=0.7.0
     , filepath
     , hashable
     , http-api-data
@@ -93,7 +92,8 @@ executable example-echo-bot
     , aeson-pretty
     , base >=4.9 && <5
     , bytestring
-    , cron
+    , cron >=0.7.0
+    , filepath
     , hashable
     , http-api-data
     , http-client
@@ -104,6 +104,7 @@ executable example-echo-bot
     , profunctors
     , servant
     , servant-client
+    , servant-multipart
     , split
     , stm
     , telegram-bot-simple
@@ -124,7 +125,8 @@ executable example-todo-bot
     , aeson-pretty
     , base >=4.9 && <5
     , bytestring
-    , cron
+    , cron >=0.7.0
+    , filepath
     , hashable
     , http-api-data
     , http-client
@@ -135,6 +137,7 @@ executable example-todo-bot
     , profunctors
     , servant
     , servant-client
+    , servant-multipart
     , split
     , stm
     , telegram-bot-simple

--- a/telegram-bot-simple.cabal
+++ b/telegram-bot-simple.cabal
@@ -19,6 +19,7 @@ copyright:      Nickolay Kudasov
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
+Tested-with:    GHC ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.10.1
 extra-source-files:
     README.md
     CHANGELOG.md


### PR DESCRIPTION
- Restrict `cron` dependency lower boundary.
- Refresh `cabal` file.