### PR TITLE
Support backwards compatibility with older ghc.

### DIFF
--- a/src/Telegram/Bot/Simple/UpdateParser.hs
+++ b/src/Telegram/Bot/Simple/UpdateParser.hs
@@ -27,6 +27,9 @@ instance Alternative UpdateParser where
 instance Monad UpdateParser where
   return = pure
   UpdateParser x >>= f = UpdateParser (\u -> x u >>= flip runUpdateParser u . f)
+#if !MIN_VERSION_base(4,13,0)
+  fail _ = empty
+#endif
 
 #if MIN_VERSION_base(4,13,0)
 instance MonadFail UpdateParser where


### PR DESCRIPTION
For base<4.13 there is a method fail, that was is equal to
`error` call unless overriden. This commit reintroduces
method overriding so parser will not exit with exception on
the call to fail.