### PR TITLE
Changed type of editMessageTextInlineMessageId

### DIFF
--- a/src/Telegram/Bot/API/UpdatingMessages.hs
+++ b/src/Telegram/Bot/API/UpdatingMessages.hs
@@ -11,6 +11,7 @@ import           GHC.Generics                    (Generic)
 import           Servant.API
 import           Servant.Client                  (ClientM, client)
 
+import           Telegram.Bot.API.InlineMode.InlineQueryResult (InlineQueryResultId)
 import           Telegram.Bot.API.Internal.Utils (gparseJSON, gtoJSON)
 import           Telegram.Bot.API.MakingRequests
 import           Telegram.Bot.API.Methods
@@ -32,7 +33,7 @@ editMessageText = client (Proxy @EditMessageText)
 data EditMessageTextRequest = EditMessageTextRequest
   { editMessageTextChatId                :: Maybe SomeChatId -- ^ Required if 'editMessageTextInlineMessageId' is not specified. Unique identifier for the target chat or username of the target channel (in the format @\@channelusername@).
   , editMessageTextMessageId             :: Maybe MessageId -- ^ Required if 'editMessageTextInlineMessageId' is not specified. Identifier of the sent message.
-  , editMessageTextInlineMessageId       :: Maybe MessageId -- ^ Required if 'editMessageTextChatId' and 'editMessageTextMessageId' are not specified. Identifier of the sent message.
+  , editMessageTextInlineMessageId       :: Maybe InlineQueryResultId -- ^ Required if 'editMessageTextChatId' and 'editMessageTextMessageId' are not specified. Identifier of the sent message.
   , editMessageTextText                  :: Text -- ^ Text of the message to be sent.
   , editMessageTextParseMode             :: Maybe ParseMode -- ^ Send 'Markdown' or 'HTML', if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
   , editMessageTextDisableWebPagePreview :: Maybe Bool -- ^ Disables link previews for links in this message.


### PR DESCRIPTION
PR related to #50 

I am not sure `InlineQueryResultId` is the right choice, maybe just `Text` would be a better fit