### PR TITLE
Added possibility of return other types instead of Action from BotM monad.

### DIFF
--- a/examples/EchoBot.hs
+++ b/examples/EchoBot.hs
@@ -14,8 +14,7 @@ import           Telegram.Bot.API.InlineMode.InputMessageContent (defaultInputTe
 type Model = ()
 
 data Action
-  = NoOp
-  | InlineEcho InlineQueryId Text
+  = InlineEcho InlineQueryId Text
   | StickerEcho InputFile ChatId
   | Echo Text
 
@@ -44,7 +43,6 @@ updateToAction update _
 
 handleAction :: Action -> Model -> Eff Action Model
 handleAction action model = case action of
-  NoOp -> pure model
   InlineEcho queryId msg -> model <# do
     _ <- liftClientM (
       answerInlineQuery (
@@ -55,7 +53,7 @@ handleAction action model = case action of
             ]
         )
       )
-    return NoOp
+    return ()
   StickerEcho file chat -> model <# do
     _ <- liftClientM 
       (sendSticker 
@@ -66,10 +64,9 @@ handleAction action model = case action of
           Nothing 
           Nothing 
           Nothing))
-    return NoOp
+    return ()
   Echo msg -> model <# do
-    replyText msg
-    return NoOp
+    pure msg -- or replyText msg
 
 run :: Token -> IO ()
 run token = do

--- a/examples/TodoBot.hs
+++ b/examples/TodoBot.hs
@@ -11,6 +11,7 @@ import qualified Data.HashMap.Strict as HashMap
 import Telegram.Bot.API
 import Telegram.Bot.Simple
 import Telegram.Bot.Simple.UpdateParser
+
 type Item = Text
 
 data Model = Model
@@ -127,4 +128,3 @@ main = do
   putStrLn "Please, enter Telegram bot's API token:"
   token <- Token . Text.pack <$> getLine
   run token
-  return ()

--- a/examples/TodoBot.hs
+++ b/examples/TodoBot.hs
@@ -11,7 +11,6 @@ import qualified Data.HashMap.Strict as HashMap
 import Telegram.Bot.API
 import Telegram.Bot.Simple
 import Telegram.Bot.Simple.UpdateParser
-
 type Item = Text
 
 data Model = Model
@@ -29,8 +28,7 @@ initialModel = Model
   }
 
 data Action
-  = NoOp
-  | Start
+  =  Start
   | AddItem Item
   | RemoveItem Item
   | SwitchToList Text
@@ -59,24 +57,18 @@ todoBot3 = BotApp
 
     handleAction :: Action -> Model -> Eff Action Model
     handleAction action model = case action of
-      NoOp -> pure model
       Start -> model <# do
         reply (toReplyMessage startMessage)
           { replyMessageReplyMarkup = Just (SomeReplyKeyboardMarkup startKeyboard) }
-        return NoOp
       AddItem item -> addItem item model <# do
         replyText "Ok, got it!"
-        return NoOp
       RemoveItem item -> removeItem item model <# do
-        replyText "Item removed!"
-        return NoOp
+        replyText "Item removed!"  
       SwitchToList name -> model { currentList = name } <# do
-        replyText ("Switched to list «" <> name <> "»!")
-        return NoOp
+        replyText ("Switched to list «" <> name <> "»!") 
       ShowAll -> model <# do
         reply (toReplyMessage "Available todo lists")
           { replyMessageReplyMarkup = Just (SomeInlineKeyboardMarkup listsKeyboard) }
-        return NoOp
       Show "" -> model <# do
         return (Show defaultListName)
       Show name -> model <# do
@@ -85,7 +77,6 @@ todoBot3 = BotApp
           then reply (toReplyMessage ("The list «" <> name <> "» is empty. Maybe try these starter options?"))
                  { replyMessageReplyMarkup = Just (SomeReplyKeyboardMarkup startKeyboard) }
           else replyText (Text.unlines items)
-        return NoOp
 
       where
         listsKeyboard = InlineKeyboardMarkup
@@ -115,6 +106,7 @@ todoBot3 = BotApp
       , replyKeyboardMarkupResizeKeyboard = Just True
       , replyKeyboardMarkupOneTimeKeyboard = Just True
       , replyKeyboardMarkupSelective = Nothing
+      , replyKeyboardMarkupInputFieldSelector = Nothing
       }
 
 addItem :: Item -> Model -> Model

--- a/package.yaml
+++ b/package.yaml
@@ -63,7 +63,7 @@ executables:
       - -with-rtsopts=-N # -N option provides concurrent running on all available cores.
 
   example-todo-bot:
-    main: examples/EchoBot.hs
+    main: examples/TodoBot.hs
     dependencies: telegram-bot-simple
     ghc-options:
       - -threaded

--- a/src/Telegram/Bot/Simple.hs
+++ b/src/Telegram/Bot/Simple.hs
@@ -11,4 +11,4 @@ import           Telegram.Bot.Simple.Conversation
 import           Telegram.Bot.Simple.Eff
 import           Telegram.Bot.Simple.InlineKeyboard
 import           Telegram.Bot.Simple.Reply
-
+import           Telegram.Bot.Simple.Instances()

--- a/src/Telegram/Bot/Simple/BotApp.hs
+++ b/src/Telegram/Bot/Simple/BotApp.hs
@@ -27,7 +27,7 @@ startBotAsync :: BotApp model action -> ClientEnv -> IO (action -> IO ())
 startBotAsync bot env = do
   botEnv <- startBotEnv bot env
   fork_ $ startBotPolling bot botEnv
-  return (issueAction botEnv Nothing)
+  return (issueAction botEnv Nothing . Just)
   where
     fork_ = void . forkIO . void . flip runClientM env
 

--- a/src/Telegram/Bot/Simple/BotApp/Internal.hs
+++ b/src/Telegram/Bot/Simple/BotApp/Internal.hs
@@ -63,7 +63,7 @@ runJobTask botEnv@BotEnv{..} task = do
         writeTVar botModelVar newModel
         return effects
   res <- flip runClientM botClientEnv $
-    mapM_ ((liftIO . issueAction botEnv Nothing) <=< applyBot (BotContext botUser Nothing)) effects
+    mapM_ ((liftIO . issueAction botEnv Nothing) <=< runBotM (BotContext botUser Nothing)) effects
   case res of
     Left err -> print err
     Right _  -> return ()
@@ -106,7 +106,7 @@ processAction BotApp{..} botEnv@BotEnv{..} update action = do
       (newModel, effects) -> do
         writeTVar botModelVar newModel
         return effects
-  mapM_ ((liftIO . issueAction botEnv update) <=< applyBot (BotContext botUser update)) effects
+  mapM_ ((liftIO . issueAction botEnv update) <=< runBotM (BotContext botUser update)) effects
 
 -- | A job to wait for the next action and process it.
 processActionJob :: BotApp model action -> BotEnv model action -> ClientM ()

--- a/src/Telegram/Bot/Simple/BotApp/Internal.hs
+++ b/src/Telegram/Bot/Simple/BotApp/Internal.hs
@@ -5,7 +5,7 @@ module Telegram.Bot.Simple.BotApp.Internal where
 
 import           Control.Concurrent      (ThreadId, forkIO, threadDelay)
 import           Control.Concurrent.STM
-import           Control.Monad           (forever, void)
+import           Control.Monad           (forever, void, (<=<))
 import           Control.Monad.Except    (catchError)
 import           Control.Monad.Trans     (liftIO)
 import           Data.Bifunctor          (first)
@@ -63,7 +63,7 @@ runJobTask botEnv@BotEnv{..} task = do
         writeTVar botModelVar newModel
         return effects
   res <- flip runClientM botClientEnv $
-    mapM_ ((>>= liftIO . issueAction botEnv Nothing) . runBotM (BotContext botUser Nothing)) effects
+    mapM_ ((liftIO . issueAction botEnv Nothing) <=< applyBot (BotContext botUser Nothing)) effects
   case res of
     Left err -> print err
     Right _  -> return ()
@@ -87,9 +87,10 @@ defaultBotEnv BotApp{..} env = BotEnv
   <*> (either (error . show) Telegram.responseResult <$> runClientM Telegram.getMe env)
 
 -- | Issue a new action for the bot to process.
-issueAction :: BotEnv model action -> Maybe Telegram.Update -> action -> IO ()
-issueAction BotEnv{..} update action = atomically $
+issueAction :: BotEnv model action -> Maybe Telegram.Update -> Maybe action -> IO ()
+issueAction BotEnv{..} update (Just action) = atomically $
   writeTQueue botActionsQueue (update, action)
+issueAction _ _ _ = pure ()
 
 -- | Process one action.
 processAction
@@ -105,7 +106,7 @@ processAction BotApp{..} botEnv@BotEnv{..} update action = do
       (newModel, effects) -> do
         writeTVar botModelVar newModel
         return effects
-  mapM_ ((>>= liftIO . issueAction botEnv update) . runBotM (BotContext botUser update)) effects
+  mapM_ ((liftIO . issueAction botEnv update) <=< applyBot (BotContext botUser update)) effects
 
 -- | A job to wait for the next action and process it.
 processActionJob :: BotApp model action -> BotEnv model action -> ClientM ()
@@ -127,7 +128,7 @@ startBotPolling BotApp{..} botEnv@BotEnv{..} = startPolling handleUpdate
       maction <- botAction update <$> readTVarIO botModelVar
       case maction of
         Nothing     -> return ()
-        Just action -> issueAction botEnv (Just update) action
+        Just action -> issueAction botEnv (Just update) (Just action)
 
 -- | Start 'Telegram.Update' polling with a given update handler.
 startPolling :: (Telegram.Update -> ClientM ()) -> ClientM ()

--- a/src/Telegram/Bot/Simple/Debug.hs
+++ b/src/Telegram/Bot/Simple/Debug.hs
@@ -70,9 +70,10 @@ traceBotActionsWith
   -> BotApp model action
 traceBotActionsWith f botApp = botApp { botHandler = newHandler }
   where
-    traceAction action = action <$ do
+    traceAction (Just action) = Just action <$ do
       liftIO $ putStrLn (f (TracedIssuedAction action))
-
+    traceAction Nothing = pure Nothing
+    
     newHandler !action model = do
       Eff (tell (map (>>= traceAction) actions))
       pure newModel

--- a/src/Telegram/Bot/Simple/Eff.hs
+++ b/src/Telegram/Bot/Simple/Eff.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE FlexibleInstances          #-}
 module Telegram.Bot.Simple.Eff where
 
 import           Control.Monad.Reader
@@ -26,27 +30,61 @@ liftClientM = BotM . lift
 runBotM :: BotContext -> BotM a -> ClientM a
 runBotM update = flip runReaderT update . _runBotM
 
-newtype Eff action model = Eff { _runEff :: Writer [BotM action] model }
+newtype Eff action model = Eff { _runEff :: Writer [Bot action] model }
   deriving (Functor, Applicative, Monad)
+
+
+data Bot action where
+  ExistBot :: (BotContext -> BotM a -> ClientM (Maybe action)) -> BotM a -> Bot action
+
+applyBot :: BotContext -> Bot action -> ClientM (Maybe action)
+applyBot context (ExistBot run effect) = run context effect
+instance Functor Bot where
+   fmap f (ExistBot run effect) = ExistBot ((fmap . fmap . fmap . fmap) f run) effect
+
+instance Applicative Bot where
+  pure a = ExistBot (pure . pure . pure . pure $ a) (pure ())
+  (ExistBot runF effF) <*> (ExistBot runV effV) = ExistBot newRun tupleEff
+    where
+      tupleEff = (,) <$> effF <*> effV
+      newRun context effect = do
+        val <- runV context (snd <$> effect)
+        func <- runF context (fst <$> effect)
+        pure (func <*> val)
+
+instance Monad Bot where
+  (ExistBot run effect) >>= fun = ExistBot newRun effect
+    where
+      newRun context effect = do
+        x <- run context effect
+        case x of
+          Nothing -> pure Nothing
+          Just a -> do
+            applyBot context (fun a) 
+
+instance MonadIO Bot where
+  liftIO action = ExistBot ((const . const) $ Just <$> liftIO action) (pure ())
+class RunBot a action where
+  runBot :: BotContext -> BotM a -> ClientM (Maybe action)
 
 instance Bifunctor Eff where
   bimap f g = Eff . mapWriter (bimap g (map (fmap f))) . _runEff
 
-runEff :: Eff action model -> (model, [BotM action])
+runEff :: Eff action model -> (model, [Bot action])
 runEff = runWriter . _runEff
 
-eff :: BotM a -> Eff a ()
-eff e = Eff (tell [e])
+eff :: RunBot a b => BotM a -> Eff b ()
+eff e = Eff (tell [ExistBot runBot e])
 
-withEffect :: BotM action -> model -> Eff action model
+withEffect :: RunBot a action => BotM a -> model -> Eff action model
 withEffect effect model = eff effect >> pure model
 
-(<#) :: model -> BotM action -> Eff action model
+(<#) :: RunBot a action => model -> BotM a -> Eff action model
 (<#) = flip withEffect
 
 -- | Set a specific 'Telegram.Update' in a 'BotM' context.
-setBotMUpdate :: Maybe Telegram.Update -> BotM a -> BotM a
-setBotMUpdate update (BotM m) = BotM (local f m)
+setBotMUpdate :: Maybe Telegram.Update -> Bot a -> Bot a
+setBotMUpdate update (ExistBot run (BotM m)) = ExistBot run $ BotM (local f m)
   where
     f botContext = botContext { botContextUpdate = update }
 

--- a/src/Telegram/Bot/Simple/Instances.hs
+++ b/src/Telegram/Bot/Simple/Instances.hs
@@ -10,12 +10,12 @@ import Telegram.Bot.Simple.Eff
 import Telegram.Bot.Simple.Reply (replyText)
 
 instance RunBot a a where
-  runBot update effect = Just <$> runBotM update effect
+  runBot effect = Just <$> effect
 
 instance RunBot () a where
-  runBot update effect = Nothing <$ runBotM  update effect
+  runBot effect = Nothing <$ effect
 
 instance RunBot Text a where
-  runBot update effect = runBot update do
+  runBot  effect = runBot do
     t <- effect
     replyText t

--- a/src/Telegram/Bot/Simple/Instances.hs
+++ b/src/Telegram/Bot/Simple/Instances.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE BlockArguments        #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# OPTIONS_GHC -Wno-orphans       #-}
+module Telegram.Bot.Simple.Instances where
+
+import Data.Text (Text)
+
+import Telegram.Bot.Simple.Eff
+import Telegram.Bot.Simple.Reply (replyText)
+
+instance RunBot a a where
+  runBot update effect = Just <$> runBotM update effect
+
+instance RunBot () a where
+  runBot update effect = Nothing <$ runBotM  update effect
+
+instance RunBot Text a where
+  runBot update effect = runBot update do
+    t <- effect
+    replyText t

--- a/telegram-bot-simple.cabal
+++ b/telegram-bot-simple.cabal
@@ -49,6 +49,7 @@ library
       Telegram.Bot.Simple.Debug
       Telegram.Bot.Simple.Eff
       Telegram.Bot.Simple.InlineKeyboard
+      Telegram.Bot.Simple.Instances
       Telegram.Bot.Simple.Reply
       Telegram.Bot.Simple.UpdateParser
   other-modules:
@@ -121,7 +122,7 @@ executable example-echo-bot
   default-language: Haskell2010
 
 executable example-todo-bot
-  main-is: examples/EchoBot.hs
+  main-is: examples/TodoBot.hs
   other-modules:
       Paths_telegram_bot_simple
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N


### PR DESCRIPTION
At this moment we have **botHandler**, that assumes user-defined **Action**-s and **BotM** monad into this handler where you make all API-requests. In this monad you must return new Action that goes back to the handler. With this design user needs to create **NoOp** -Action that doesn't produce any **BotM**-actions and therefore does not produce new Action-s.
This PR creates solver, that can works with arbitrary return types, that have **RunBot a Action**-instance. 