### PR TITLE
Make `startPolling` polymorphic

### DIFF
--- a/src/Telegram/Bot/Simple/BotApp/Internal.hs
+++ b/src/Telegram/Bot/Simple/BotApp/Internal.hs
@@ -131,7 +131,7 @@ startBotPolling BotApp{..} botEnv@BotEnv{..} = startPolling handleUpdate
         Just action -> issueAction botEnv (Just update) (Just action)
 
 -- | Start 'Telegram.Update' polling with a given update handler.
-startPolling :: (Telegram.Update -> ClientM ()) -> ClientM ()
+startPolling :: (Telegram.Update -> ClientM a) -> ClientM a
 startPolling handleUpdate = go Nothing
   where
     go lastUpdateId = do


### PR DESCRIPTION
Making the `startPolling` function polymorphic will enable it to be used in the context of different monadic stacks (as opposed to pure `ClientM`), more specifically functions like `liftWith` or `liftBaseWith` from `Monad{Base,Trans}Control`.