### PR TITLE
Fix the most comments from backlog

### DIFF
--- a/examples/EchoBot.hs
+++ b/examples/EchoBot.hs
@@ -44,7 +44,7 @@ updateToAction update _
 handleAction :: Action -> Model -> Eff Action Model
 handleAction action model = case action of
   InlineEcho queryId msg -> model <# do
-    let result = InlineQueryResult InlineQueryResultArticle (InlineQueryResultId msg) (Just msg) (Just (defaultInputTextMessageContent msg))
+    let result = InlineQueryResult InlineQueryResultArticle (InlineQueryResultId msg) (Just msg) (Just (defaultInputTextMessageContent msg)) Nothing
         answerInlineQueryRequest = AnswerInlineQueryRequest
           { answerInlineQueryRequestInlineQueryId = queryId
           , answerInlineQueryRequestResults       = [result]

--- a/examples/GameBot.hs
+++ b/examples/GameBot.hs
@@ -107,6 +107,7 @@ handleAction BotSettings{..} action model = case action of
             (InlineQueryResultId msg)
             (Just msg)
             (Just gameMsg)
+            Nothing
         gameMsg = (defaultInputTextMessageContent gameMessageText) { inputMessageContentParseMode = Just "HTML" }
         answerInlineQueryRequest = AnswerInlineQueryRequest
           { answerInlineQueryRequestInlineQueryId = queryId

--- a/src/Telegram/Bot/API/GettingUpdates.hs
+++ b/src/Telegram/Bot/API/GettingUpdates.hs
@@ -40,8 +40,8 @@ data Update = Update
 
   , updateCallbackQuery     :: Maybe CallbackQuery -- ^ New incoming callback query
 
---   , updateShippingQuery :: Maybe ShippingQuery -- ^ New incoming shipping query. Only for invoices with flexible price
---   , updatePreCheckoutQuery :: Maybe PreCheckoutQuery -- ^ New incoming pre-checkout query. Contains full information about checkout
+  , updateShippingQuery     :: Maybe ShippingQuery -- ^ New incoming shipping query. Only for invoices with flexible price
+  , updatePreCheckoutQuery  :: Maybe PreCheckoutQuery -- ^ New incoming pre-checkout query. Contains full information about checkout
   } deriving (Generic, Show)
 
 instance ToJSON   Update where toJSON = gtoJSON

--- a/src/Telegram/Bot/API/InlineMode/InlineQueryResult.hs
+++ b/src/Telegram/Bot/API/InlineMode/InlineQueryResult.hs
@@ -9,6 +9,7 @@ import           Data.Text                       (Text)
 import           GHC.Generics                    (Generic)
 
 import           Telegram.Bot.API.Internal.Utils
+import           Telegram.Bot.API.Types (Contact)
 import           Telegram.Bot.API.InlineMode.InputMessageContent
 
 -- | This object represents one result of an inline query
@@ -17,7 +18,7 @@ data InlineQueryResult = InlineQueryResult
   , inlineQueryResultId :: InlineQueryResultId -- ^ Unique identifier for this result, 1-64 Bytes
   , inlineQueryResultTitle :: Maybe Text -- ^ Title of the result (only valid for "Article", "Photo", "Gif", "Mpeg4Gif", "Video", "Audio", "Voice", "Document", "Location", "Venue", "CachedPhoto", "CachedGif", "CachedMpeg4Gif", "CachedDocument", "CachedVideo", "CachedVoice" types of results)
   , inlineQueryResultInputMessageContent :: Maybe InputMessageContent
---  , inlineQueryResultContact  :: Maybe Contact
+  , inlineQueryResultContact  :: Maybe Contact
   } deriving (Generic, Show)
 
 newtype InlineQueryResultId = InlineQueryResultId Text

--- a/src/Telegram/Bot/API/MakingRequests.hs
+++ b/src/Telegram/Bot/API/MakingRequests.hs
@@ -1,9 +1,16 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings          #-}
 module Telegram.Bot.API.MakingRequests where
 
 import           Data.Aeson                      (FromJSON (..), ToJSON (..))
+#if defined(MIN_VERSION_GLASGOW_HASKELL)
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,2,0)
+#else
+import           Data.Monoid                     ((<>))
+#endif
+#endif
 import           Data.String                     (IsString)
 import           Data.Text                       (Text)
 import qualified Data.Text                       as Text

--- a/src/Telegram/Bot/API/Methods.hs
+++ b/src/Telegram/Bot/API/Methods.hs
@@ -791,7 +791,7 @@ data EditMessageLiveLocationRequest = EditMessageLiveLocationRequest
 
 type EditMessageLiveLocation = "editMessageLiveLocation"
   :> ReqBody '[JSON] EditMessageLiveLocationRequest
-  :> Post '[JSON] (Response Message)
+  :> Post '[JSON] (Response (Either Bool Message))
 
 -- FIXME: Add Bool returning in case of inline message. 
 
@@ -801,7 +801,7 @@ type EditMessageLiveLocation = "editMessageLiveLocation"
 --   call to stopMessageLiveLocation. On success, if
 --   the edited message is not an inline message, the
 --   edited Message is returned, otherwise True is returned.
-editMessageLiveLocation :: EditMessageLiveLocationRequest ->  ClientM (Response Message)
+editMessageLiveLocation :: EditMessageLiveLocationRequest ->  ClientM (Response (Either Bool Message))
 editMessageLiveLocation = client (Proxy @EditMessageLiveLocation)
 
 -- | Request parameters for 'stopMessageLiveLocation'.
@@ -815,7 +815,7 @@ data StopMessageLiveLocationRequest = StopMessageLiveLocationRequest
 
 type StopMessageLiveLocation = "stopMessageLiveLocation"
   :> ReqBody '[JSON] StopMessageLiveLocationRequest
-  :> Post '[JSON] (Response Message)
+  :> Post '[JSON] (Response (Either Bool Message))
 
 -- FIXME: Add Bool returning in case of inline message. 
 
@@ -824,7 +824,7 @@ type StopMessageLiveLocation = "stopMessageLiveLocation"
 --   expires. On success, if the message is
 --   not an inline message, the edited Message
 --   is returned, otherwise True is returned.
-stopMessageLiveLocation :: StopMessageLiveLocationRequest ->  ClientM (Response Message)
+stopMessageLiveLocation :: StopMessageLiveLocationRequest ->  ClientM (Response (Either Bool Message))
 stopMessageLiveLocation = client (Proxy @StopMessageLiveLocation)
 
 -- | Request parameters for 'sendVenue'.
@@ -1274,8 +1274,6 @@ declineChatJoinRequest :: SomeChatId -- ^ Unique identifier for the target chat 
   -> ClientM (Response Bool)
 declineChatJoinRequest = client (Proxy @DeclineChatJoinRequest)
 
--- FIXME: Unsafe usage of InputFile - valid only InputFile constructor.
-
 -- | Request parameters for 'setChatPhoto'.
 data SetChatPhotoRequest = SetChatPhotoRequest
   { setChatPhotoChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -1301,6 +1299,9 @@ type SetChatPhoto = "setChatPhoto"
 --   administrator in the chat for this to work 
 --   and must have the appropriate administrator rights. 
 --   Returns True on success.
+--
+-- *Note*: Only 'InputFile' case might be used in 'SetChatPhotoRequest'.
+-- Rest cases will be rejected by Telegram.
 setChatPhoto :: SetChatPhotoRequest ->  ClientM (Response Bool)
 setChatPhoto r =do
       boundary <- liftIO genBoundary

--- a/src/Telegram/Bot/API/Types.hs
+++ b/src/Telegram/Bot/API/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -783,17 +784,11 @@ data ResponseParameters = ResponseParameters
   }
   deriving (Show, Generic)
 
--- FIXME: Decide about 'BotCommandScope' types.
-
--- FIXME: Decide about 'InputMedia' types.
-
 -- * Stickers
 
 -- | The following methods and objects allow your bot to handle stickers and sticker sets.
 
 -- ** 'Sticker'
-
--- FIXME: sticker.set_name vs sticker_set.name?
 
 -- | This object represents a sticker.
 data Sticker = Sticker
@@ -804,7 +799,7 @@ data Sticker = Sticker
   , stickerIsAnimated   :: Bool               -- ^ True, if the sticker is animated.
   , stickerThumb        :: Maybe PhotoSize    -- ^ Sticker thumbnail in the .WEBP or .JPG format.
   , stickerEmoji        :: Maybe Text         -- ^ Emoji associated with the sticker.
-  , stickerSetName_     :: Maybe Text         -- ^ Name of the sticker set to which the sticker belongs.
+  , stickerSetName      :: Maybe Text         -- ^ Name of the sticker set to which the sticker belongs.
   , stickerMaskPosition :: Maybe MaskPosition -- ^ For mask stickers, the position where the mask should be placed.
   , stickerFileSize     :: Maybe Integer      -- ^ File size in bytes.
   }
@@ -1343,4 +1338,6 @@ foldMap deriveJSON'
   , ''ChatInviteLink
   , ''LabeledPrice
   , ''ShippingOption
+  , ''ShippingQuery
+  , ''PreCheckoutQuery
   ]

--- a/src/Telegram/Bot/API/UpdatingMessages.hs
+++ b/src/Telegram/Bot/API/UpdatingMessages.hs
@@ -22,11 +22,10 @@ import           Telegram.Bot.API.Types
 type EditMessageText
   = "editMessageText"
   :> ReqBody '[JSON] EditMessageTextRequest
-  :> Post '[JSON] (Response Message)
+  :> Post '[JSON] (Response (Either Bool Message))
 
--- | Use this method to send text messages.
--- On success, the sent 'Message' is returned.
-editMessageText :: EditMessageTextRequest -> ClientM (Response Message)
+-- | Use this method to edit text and game messages. On success, if the edited message is not an inline message, the edited 'Message' is returned, otherwise 'True' is returned.
+editMessageText :: EditMessageTextRequest -> ClientM (Response (Either Bool Message))
 editMessageText = client (Proxy @EditMessageText)
 
 -- | Request parameters for 'editMessageText'.
@@ -54,13 +53,13 @@ data EditMessageCaptionRequest = EditMessageCaptionRequest
 
 type EditMessageCaption  = "editMessageCaption"
   :> ReqBody '[JSON] EditMessageCaptionRequest
-  :> Post '[JSON] (Response Message)
+  :> Post '[JSON] (Response (Either Bool Message))
 
 -- | Use this method to edit captions of messages.
 --   On success, if the edited message is not an
 --   inline message, the edited Message is returned,
 --   otherwise True is returned.
-editMessageCaption :: EditMessageCaptionRequest -> ClientM (Response Message)
+editMessageCaption :: EditMessageCaptionRequest -> ClientM (Response (Either Bool Message))
 editMessageCaption = client (Proxy @EditMessageCaption)
 
 -- | Request parameters for 'editMessageMedia'.
@@ -76,7 +75,7 @@ instance ToJSON EditMessageMediaRequest where toJSON = gtoJSON
 
 type EditMessageMedia  = "editMessageMedia"
   :> ReqBody '[JSON] EditMessageMediaRequest
-  :> Post '[JSON] (Response Message)
+  :> Post '[JSON] (Response (Either Bool Message))
 
 -- | Use this method to edit animation, audio,
 --   document, photo, or video messages. If a
@@ -88,7 +87,7 @@ type EditMessageMedia  = "editMessageMedia"
 --   previously uploaded file via its file_id or specify a URL.
 --   On success, if the edited message is not an inline
 --   message, the edited Message is returned, otherwise True is returned.
-editMessageMedia :: EditMessageMediaRequest -> ClientM (Response Message)
+editMessageMedia :: EditMessageMediaRequest -> ClientM (Response (Either Bool Message))
 editMessageMedia = client (Proxy @EditMessageMedia)
 
 -- | Request parameters for 'editMessageReplyMarkup'.
@@ -102,12 +101,12 @@ data EditMessageReplyMarkupRequest = EditMessageReplyMarkupRequest
 
 type EditMessageReplyMarkup = "editMessageReplyMarkup"
   :> ReqBody '[JSON] EditMessageReplyMarkupRequest
-  :> Post '[JSON] (Response Message)
+  :> Post '[JSON] (Response (Either Bool Message))
 
 -- | Use this method to edit only the reply markup of messages.
 --   On success, if the edited message is not an inline message,
 --   the edited Message is returned, otherwise True is returned.
-editMessageReplyMarkup :: EditMessageReplyMarkupRequest -> ClientM (Response Message)
+editMessageReplyMarkup :: EditMessageReplyMarkupRequest -> ClientM (Response (Either Bool Message))
 editMessageReplyMarkup = client (Proxy @EditMessageReplyMarkup)
 
 -- | Request parameters for 'stopPoll'.

--- a/src/Telegram/Bot/Simple/Debug.hs
+++ b/src/Telegram/Bot/Simple/Debug.hs
@@ -1,10 +1,17 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 module Telegram.Bot.Simple.Debug where
 
 import           Control.Monad.Trans        (liftIO)
 import           Control.Monad.Writer       (tell)
 import           Data.Aeson                 (ToJSON)
 import qualified Data.Aeson.Encode.Pretty   as Aeson
+#if defined(MIN_VERSION_GLASGOW_HASKELL)
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,2,0)
+#else
+import           Data.Monoid                     ((<>))
+#endif
+#endif
 import qualified Data.Text.Lazy             as Text
 import qualified Data.Text.Lazy.Encoding    as Text
 import           Debug.Trace                (trace)

--- a/src/Telegram/Bot/Simple/UpdateParser.hs
+++ b/src/Telegram/Bot/Simple/UpdateParser.hs
@@ -5,6 +5,12 @@ module Telegram.Bot.Simple.UpdateParser where
 
 import           Control.Applicative
 import           Control.Monad.Reader
+#if defined(MIN_VERSION_GLASGOW_HASKELL)
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,2,0)
+#else
+import           Data.Monoid                     ((<>))
+#endif
+#endif
 import           Data.Text            (Text)
 import qualified Data.Text            as Text
 import           Text.Read            (readMaybe)


### PR DESCRIPTION
- Uncomment all commented records.
- Resolve all `fixme` comments.
- Return `Data.Monoid` but only for affected GHCs.
- Conditional response types (`Either Bool Message`).
- `sticker.set_name` vs. `sticker_set.name`.