### PR TITLE
Add MarkdownV2 to ParseMode suggestion

### DIFF
--- a/src/Telegram/Bot/API/Methods.hs
+++ b/src/Telegram/Bot/API/Methods.hs
@@ -103,7 +103,7 @@ instance FromJSON ParseMode
 data SendMessageRequest = SendMessageRequest
   { sendMessageChatId                :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername@).
   , sendMessageText                  :: Text -- ^ Text of the message to be sent.
-  , sendMessageParseMode             :: Maybe ParseMode -- ^ Send 'Markdown' or 'HTML', if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , sendMessageParseMode             :: Maybe ParseMode -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
   , sendMessageEntities              :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in message text, which can be specified instead of /parse_mode/.
   , sendMessageDisableWebPagePreview :: Maybe Bool -- ^ Disables link previews for links in this message.
   , sendMessageDisableNotification   :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.

--- a/src/Telegram/Bot/API/UpdatingMessages.hs
+++ b/src/Telegram/Bot/API/UpdatingMessages.hs
@@ -25,7 +25,7 @@ data EditMessageTextRequest = EditMessageTextRequest
   , editMessageTextMessageId             :: Maybe MessageId -- ^ Required if 'editMessageTextInlineMessageId' is not specified. Identifier of the sent message.
   , editMessageTextInlineMessageId       :: Maybe MessageId -- ^ Required if 'editMessageTextChatId' and 'editMessageTextMessageId' are not specified. Identifier of the sent message.
   , editMessageTextText                  :: Text -- ^ Text of the message to be sent.
-  , editMessageTextParseMode             :: Maybe ParseMode -- ^ Send 'Markdown' or 'HTML', if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , editMessageTextParseMode             :: Maybe ParseMode -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
   , editMessageEntities                  :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in message text, which can be specified instead of /parse_mode/.
   , editMessageTextDisableWebPagePreview :: Maybe Bool -- ^ Disables link previews for links in this message.
   , editMessageTextReplyMarkup           :: Maybe SomeReplyMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.

--- a/src/Telegram/Bot/Simple/Reply.hs
+++ b/src/Telegram/Bot/Simple/Reply.hs
@@ -37,7 +37,7 @@ updateEditMessageId update
 -- This is just like 'SendMessageRequest' but without 'SomeChatId' specified.
 data ReplyMessage = ReplyMessage
   { replyMessageText                  :: Text -- ^ Text of the message to be sent.
-  , replyMessageParseMode             :: Maybe ParseMode -- ^ Send 'Markdown' or 'HTML', if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , replyMessageParseMode             :: Maybe ParseMode -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
   , replyMessageEntities              :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in message text, which can be specified instead of /parse_mode/.
   , replyMessageDisableWebPagePreview :: Maybe Bool -- ^ Disables link previews for links in this message.
   , replyMessageDisableNotification   :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.


### PR DESCRIPTION
Suggest MarkdownV2 for ParseMode instead of Markdown, since the latter "is a legacy mode, retained for backward compatibility".