### PR TITLE
Fix copyMessage method

### DIFF
--- a/src/Telegram/Bot/API/Methods.hs
+++ b/src/Telegram/Bot/API/Methods.hs
@@ -1372,7 +1372,7 @@ foldMap deriveJSON'
 type CopyMessage
   = "copyMessage"
   :> ReqBody '[JSON] CopyMessageRequest
-  :> Post '[JSON] (Response MessageId)
+  :> Post '[JSON] (Response CopyMessageId)
 
 -- | Use this method to copy messages of any kind.
 --   Service messages and invoice messages can't be
@@ -1380,7 +1380,7 @@ type CopyMessage
 --   forwardMessage, but the copied message doesn't
 --   have a link to the original message.
 --   Returns the MessageId of the sent message on success.
-copyMessage :: CopyMessageRequest ->  ClientM (Response MessageId)
+copyMessage :: CopyMessageRequest ->  ClientM (Response CopyMessageId)
 copyMessage = client (Proxy @CopyMessage)
 
 type SendLocation = "sendLocation"

--- a/src/Telegram/Bot/API/Types.hs
+++ b/src/Telegram/Bot/API/Types.hs
@@ -1108,6 +1108,15 @@ data GameHighScore = GameHighScore
   }
   deriving (Generic, Show)
 
+-- ** 'CopyMessageId'
+
+-- | This object represents result of copyMessage request.
+data CopyMessageId = CopyMessageId
+  { copyMessageIdMessageId :: MessageId -- ^ the MessageId of the sent message.
+  }
+  deriving (Generic, Show)
+
+
 -- | Unique identifier for the target chat
 -- or username of the target channel (in the format @\@channelusername@).
 data SomeChatId
@@ -1275,6 +1284,7 @@ foldMap deriveJSON'
   , ''WebAppData
   , ''WebAppInfo
   , ''ChatAdministratorRights
+  , ''CopyMessageId
   ]
 
 instance ToJSON InputMediaGeneric where toJSON = gtoJSON


### PR DESCRIPTION
Expect an Object of `{"message_id": 2144}` shape from `copyMessage` instead of just a `Number`.
See #117 