### PR TITLE
Added `commandBotName`

### DIFF
--- a/src/Telegram/Bot/Simple/UpdateParser.hs
+++ b/src/Telegram/Bot/Simple/UpdateParser.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 module Telegram.Bot.Simple.UpdateParser where
 
 import           Control.Applicative
@@ -8,7 +8,7 @@ import           Control.Monad.Reader
 #if defined(MIN_VERSION_GLASGOW_HASKELL)
 #if MIN_VERSION_GLASGOW_HASKELL(8,6,2,0)
 #else
-import           Data.Monoid                     ((<>))
+import           Data.Monoid          ((<>))
 #endif
 #endif
 import           Data.Text            (Text)

--- a/src/Telegram/Bot/Simple/UpdateParser.hs
+++ b/src/Telegram/Bot/Simple/UpdateParser.hs
@@ -65,6 +65,9 @@ command name = do
       -> pure (Text.unwords ws)
     _ -> fail "not that command"
 
+commandBotName :: Text -> Text -> UpdateParser Text
+commandBotName name botName = command name <|> command (Text.intercalate "@" [name, botName])
+
 commandWithBotName :: Text -> Text -> UpdateParser Text
 commandWithBotName botname commandname = do
   t <- text


### PR DESCRIPTION
According to telegram bot API reference bot should be able to understand command followed by `@bot_id`.

Created `commandBotName` function to enable this behaviour.