### PR TITLE
[#125] Move from short polling to the long one

### DIFF
--- a/src/Telegram/Bot/Simple/BotApp/Internal.hs
+++ b/src/Telegram/Bot/Simple/BotApp/Internal.hs
@@ -139,7 +139,7 @@ startPolling handleUpdate = go Nothing
           offset = fmap inc lastUpdateId
       res <-
         (Right <$> Telegram.getUpdates
-          (Telegram.GetUpdatesRequest offset Nothing Nothing Nothing))
+          (Telegram.GetUpdatesRequest offset Nothing (Just 25) Nothing))
         `catchError` (pure . Left)
 
       nextUpdateId <- case res of

--- a/telegram-bot-simple.cabal
+++ b/telegram-bot-simple.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -129,12 +129,12 @@ executable example-echo-bot
     , unordered-containers
     , warp
     , warp-tls
+  default-language: Haskell2010
   if flag(examples)
     build-depends:
         telegram-bot-simple
   else
     buildable: False
-  default-language: Haskell2010
 
 executable example-echo-bot-webhook
   main-is: examples/EchoBotWebhook.hs
@@ -170,12 +170,12 @@ executable example-echo-bot-webhook
     , unordered-containers
     , warp
     , warp-tls
+  default-language: Haskell2010
   if flag(examples)
     build-depends:
         telegram-bot-simple
   else
     buildable: False
-  default-language: Haskell2010
 
 executable example-game-bot
   main-is: examples/GameBot.hs
@@ -211,6 +211,7 @@ executable example-game-bot
     , unordered-containers
     , warp
     , warp-tls
+  default-language: Haskell2010
   if flag(examples)
     build-depends:
         QuickCheck
@@ -229,7 +230,6 @@ executable example-game-bot
       , warp
   else
     buildable: False
-  default-language: Haskell2010
 
 executable example-todo-bot
   main-is: examples/TodoBot.hs
@@ -265,9 +265,9 @@ executable example-todo-bot
     , unordered-containers
     , warp
     , warp-tls
+  default-language: Haskell2010
   if flag(examples)
     build-depends:
         telegram-bot-simple
   else
     buildable: False
-  default-language: Haskell2010


### PR DESCRIPTION
In [telegram bot API documentation](https://core.telegram.org/bots/api#getupdates) is written, that "Timeout in seconds for long polling. Defaults to 0, i.e. usual short polling. Should be positive, **short polling should be used for testing purposes only.**"(c)

So, let's stop to eat CPU and DoS telegram servers. I added timeout in 25 seconds, but I didn't test it, so we may increase or decrease this value.