### PR TITLE
fixed DecodeFailure from incorrect field video_chat_started parsing

### DIFF
--- a/src/Telegram/Bot/API/Types.hs
+++ b/src/Telegram/Bot/API/Types.hs
@@ -458,6 +458,13 @@ data VideoChatScheduled = VideoChatScheduled
 data VideoChatStarted = VideoChatStarted
   deriving (Generic, Show)
 
+instance ToJSON VideoChatStarted where
+  toJSON = gtoJSON
+
+instance FromJSON VideoChatStarted where
+  parseJSON (Data.Aeson.Object _) = pure VideoChatStarted
+  parseJSON _ = fail "Unable to parse VideoChatStarted: expected either an empty object"
+
 -- ** 'VideoChatEnded'
 
 -- | This object represents a service message about a video chat ended in the chat.
@@ -1275,7 +1282,6 @@ foldMap deriveJSON'
   , ''EncryptedCredentials
   , ''ProximityAlertTriggered
   , ''VideoChatScheduled
-  , ''VideoChatStarted
   , ''VideoChatEnded
   , ''VideoChatParticipantsInvited
   , ''ChatPermissions

--- a/src/Telegram/Bot/API/Types.hs
+++ b/src/Telegram/Bot/API/Types.hs
@@ -463,7 +463,7 @@ instance ToJSON VideoChatStarted where
 
 instance FromJSON VideoChatStarted where
   parseJSON (Data.Aeson.Object _) = pure VideoChatStarted
-  parseJSON _ = fail "Unable to parse VideoChatStarted: expected either an empty object"
+  parseJSON _ = fail "Unable to parse VideoChatStarted: expected an empty object"
 
 -- ** 'VideoChatEnded'
 


### PR DESCRIPTION
fixed an error 
DecodeFailure "Error in $.result[0].message['video_chat_started']: When parsing the constructor VideoChatStarted of type Telegram.Bot.API.Types.VideoChatStarted expected Array but got Object."
when that crushed the bot that occurs when a group chat call is in place.    
The chat JSON contained
\"video_chat_started\":{}
attached full error message in file

[error.txt](https://github.com/fizruk/telegram-bot-simple/files/10369707/error.txt)
