### PR TITLE
Split Types and Methods, remove `Request` suffix from fields

### DIFF
--- a/examples/GameBot.hs
+++ b/examples/GameBot.hs
@@ -123,14 +123,14 @@ handleAction BotSettings{..} action model = case action of
     return ()
   AGame targetChatId msg -> model <# do
     let sendGameRequest = SendGameRequest
-          { sendGameRequestChatId                   = coerce targetChatId
-          , sendGameRequestMessageThreadId          = Nothing
-          , sendGameRequestGameShortName            = gameId
-          , sendGameRequestDisableNotification      = Nothing
+          { sendGameChatId                   = coerce targetChatId
+          , sendGameMessageThreadId          = Nothing
+          , sendGameGameShortName            = gameId
+          , sendGameDisableNotification      = Nothing
           , sendGameProtectContent                  = Nothing
-          , sendGameRequestReplyToMessageId         = Nothing
-          , sendGameRequestAllowSendingWithoutReply = Nothing
-          , sendGameRequestReplyMarkup              = Nothing
+          , sendGameReplyToMessageId         = Nothing
+          , sendGameAllowSendingWithoutReply = Nothing
+          , sendGameReplyMarkup              = Nothing
           }
     _ <- liftClientM $ sendGame sendGameRequest
     return ()

--- a/src/Telegram/Bot/API/Forum.hs
+++ b/src/Telegram/Bot/API/Forum.hs
@@ -36,9 +36,9 @@ getForumTopicIconStickers = client (Proxy @GetForumTopicIconStickers)
 
 data CreateForumTopicRequest = CreateForumTopicRequest
   { createForumTopicRequestChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
-  , createForumTopicRequestName :: Text -- ^ Topic name, 1-128 characters.
-  , createForumTopicRequestIconColor :: Maybe Integer -- ^ Color of the topic icon in RGB format. Currently, must be one of @7322096 (0x6FB9F0), 16766590 (0xFFD67E), 13338331 (0xCB86DB), 9367192 (0x8EEE98), 16749490 (0xFF93B2), or 16478047 (0xFB6F5F)@.
-  , createForumTopicRequestIconCustomEmojiId :: Maybe Text -- ^ Unique identifier of the custom emoji shown as the topic icon. Use 'getForumTopicIconStickers' to get all allowed custom emoji identifiers.
+  , createForumTopicName :: Text -- ^ Topic name, 1-128 characters.
+  , createForumTopicIconColor :: Maybe Integer -- ^ Color of the topic icon in RGB format. Currently, must be one of @7322096 (0x6FB9F0), 16766590 (0xFFD67E), 13338331 (0xCB86DB), 9367192 (0x8EEE98), 16749490 (0xFF93B2), or 16478047 (0xFB6F5F)@.
+  , createForumTopicIconCustomEmojiId :: Maybe Text -- ^ Unique identifier of the custom emoji shown as the topic icon. Use 'getForumTopicIconStickers' to get all allowed custom emoji identifiers.
   }
   deriving Generic
 
@@ -78,8 +78,8 @@ editForumTopic = client (Proxy @EditForumTopic)
 -- ** 'closeForumTopic'
 
 data CloseForumTopicRequest = CloseForumTopicRequest
-  { closeForumTopicRequestChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
-  , closeForumTopicRequestMessageThreadId :: MessageThreadId -- ^ Unique identifier for the target message thread of the forum topic.
+  { closeForumTopicChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
+  , closeForumTopicMessageThreadId :: MessageThreadId -- ^ Unique identifier for the target message thread of the forum topic.
   }
   deriving Generic
 
@@ -97,8 +97,8 @@ closeForumTopic = client (Proxy @CloseForumTopic)
 -- ** 'reopenForumTopic'
 
 data ReopenForumTopicRequest = ReopenForumTopicRequest
-  { reopenForumTopicRequestChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
-  , reopenForumTopicRequestMessageThreadId :: MessageThreadId -- ^ Unique identifier for the target message thread of the forum topic.
+  { reopenForumTopicChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
+  , reopenForumTopicMessageThreadId :: MessageThreadId -- ^ Unique identifier for the target message thread of the forum topic.
   }
   deriving Generic
 
@@ -116,8 +116,8 @@ reopenForumTopic = client (Proxy @ReopenForumTopic)
 -- ** 'deleteForumTopic'
 
 data DeleteForumTopicRequest = DeleteForumTopicRequest
-  { deleteForumTopicRequestChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
-  , deleteForumTopicRequestMessageThreadId :: MessageThreadId -- ^ Unique identifier for the target message thread of the forum topic.
+  { deleteForumTopicChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
+  , deleteForumTopicMessageThreadId :: MessageThreadId -- ^ Unique identifier for the target message thread of the forum topic.
   }
   deriving Generic
 
@@ -135,8 +135,8 @@ deleteForumTopic = client (Proxy @DeleteForumTopic)
 -- ** 'unpinAllForumTopicMessages'
 
 data UnpinAllForumTopicMessagesRequest = UnpinAllForumTopicMessagesRequest
-  { unpinAllForumTopicMessagesRequestChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  , unpinAllForumTopicMessagesRequestMessageThreadId :: MessageThreadId -- ^ Unique identifier for the target message thread of the forum topic.
+  { unpinAllForumTopicMessagesChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  , unpinAllForumTopicMessagesMessageThreadId :: MessageThreadId -- ^ Unique identifier for the target message thread of the forum topic.
   }
   deriving Generic
 
@@ -154,8 +154,8 @@ unpinAllForumTopicMessages = client (Proxy @UnpinAllForumTopicMessages)
 -- ** 'editGeneralForumTopic'
 
 data EditGeneralForumTopicRequest = EditGeneralForumTopicRequest
-  { editGeneralForumTopicRequestChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
-  , editGeneralForumTopicRequestName :: Text -- ^ New topic name, 1-128 characters.
+  { editGeneralForumTopicChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
+  , editGeneralForumTopicName :: Text -- ^ New topic name, 1-128 characters.
   }
   deriving Generic
 
@@ -209,7 +209,7 @@ reopenGeneralForumTopic = client (Proxy @ReopenGeneralForumTopic)
 -- ** 'hideGeneralForumTopic'
 
 data HideGeneralForumTopicRequest = HideGeneralForumTopicRequest
-  { hideGeneralForumTopicRequestChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
+  { hideGeneralForumTopicChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
   }
   deriving Generic
 
@@ -227,7 +227,7 @@ hideGeneralForumTopic = client (Proxy @HideGeneralForumTopic)
 -- ** 'unhideGeneralForumTopic'
 
 data UnhideGeneralForumTopicRequest = UnhideGeneralForumTopicRequest
-  { unhideGeneralForumTopicRequestChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  { unhideGeneralForumTopicChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
   }
   deriving Generic
 

--- a/src/Telegram/Bot/API/Games.hs
+++ b/src/Telegram/Bot/API/Games.hs
@@ -22,27 +22,27 @@ import Telegram.Bot.API.Types (ChatId, GameHighScore, InlineKeyboardMarkup, Mess
 -- ** 'SendGameRequest'
 
 data SendGameRequest = SendGameRequest
-  { sendGameRequestChatId                   :: ChatId                     -- ^ Unique identifier for the target chat.
-  , sendGameRequestMessageThreadId          :: Maybe MessageThreadId      -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendGameRequestGameShortName            :: Text                       -- ^ Short name of the game, serves as the unique identifier for the game. Set up your games via Botfather.
-  , sendGameRequestDisableNotification      :: Maybe Bool                 -- ^ Sends the message silently. Users will receive a notification with no sound.
+  { sendGameChatId                   :: ChatId                     -- ^ Unique identifier for the target chat.
+  , sendGameMessageThreadId          :: Maybe MessageThreadId      -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendGameGameShortName            :: Text                       -- ^ Short name of the game, serves as the unique identifier for the game. Set up your games via Botfather.
+  , sendGameDisableNotification      :: Maybe Bool                 -- ^ Sends the message silently. Users will receive a notification with no sound.
   , sendGameProtectContent                  :: Maybe Bool                 -- ^ Protects the contents of the sent message from forwarding and saving.  
-  , sendGameRequestReplyToMessageId         :: Maybe MessageId            -- ^ If the message is a reply, ID of the original message.
-  , sendGameRequestAllowSendingWithoutReply :: Maybe Bool                 -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found
-  , sendGameRequestReplyMarkup              :: Maybe InlineKeyboardMarkup -- ^ A JSON-serialized object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game.
+  , sendGameReplyToMessageId         :: Maybe MessageId            -- ^ If the message is a reply, ID of the original message.
+  , sendGameAllowSendingWithoutReply :: Maybe Bool                 -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found
+  , sendGameReplyMarkup              :: Maybe InlineKeyboardMarkup -- ^ A JSON-serialized object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game.
   }
   deriving (Generic, Show)
 
 -- ** 'SetGameScoreRequest'
 
 data SetGameScoreRequest = SetGameScoreRequest
-  { setGameScoreRequestUserId             :: UserId          -- ^ User identifier.
-  , setGameScoreRequestScore              :: Integer         -- ^ New score, must be non-negative.
-  , setGameScoreRequestForce              :: Maybe Bool      -- ^ Pass 'True', if the high score is allowed to decrease. This can be useful when fixing mistakes or banning cheaters.
-  , setGameScoreRequestDisableEditMessage :: Maybe Bool      -- ^ Pass 'True', if the game message should not be automatically edited to include the current scoreboard.
-  , setGameScoreRequestChatId             :: Maybe ChatId    -- ^ Required if @inline_message_id@ is not specified. Unique identifier for the target chat
-  , setGameScoreRequestMessageId          :: Maybe MessageId -- ^ Required if @inline_message_id@ is not specified. Identifier of the sent message.
-  , setGameScoreRequestInlineMessageId    :: Maybe MessageId -- ^ Required if @chat_id@ and @message_id@ are not specified. Identifier of the inline message.
+  { setGameScoreUserId             :: UserId          -- ^ User identifier.
+  , setGameScoreScore              :: Integer         -- ^ New score, must be non-negative.
+  , setGameScoreForce              :: Maybe Bool      -- ^ Pass 'True', if the high score is allowed to decrease. This can be useful when fixing mistakes or banning cheaters.
+  , setGameScoreDisableEditMessage :: Maybe Bool      -- ^ Pass 'True', if the game message should not be automatically edited to include the current scoreboard.
+  , setGameScoreChatId             :: Maybe ChatId    -- ^ Required if @inline_message_id@ is not specified. Unique identifier for the target chat
+  , setGameScoreMessageId          :: Maybe MessageId -- ^ Required if @inline_message_id@ is not specified. Identifier of the sent message.
+  , setGameScoreInlineMessageId    :: Maybe MessageId -- ^ Required if @chat_id@ and @message_id@ are not specified. Identifier of the inline message.
   }
   deriving (Generic, Show)
 
@@ -54,10 +54,10 @@ data SetGameScoreResult = SetGameScoreMessage Message | SetGameScoreMessageBool 
 -- ** 'GetGameHighScoresRequest'
 
 data GetGameHighScoresRequest = GetGameHighScoresRequest
-  { getGameHighScoresRequestUserId          :: UserId          -- ^ Target user id.
-  , getGameHighScoresRequestChatId          :: Maybe ChatId    -- ^ Required if @inline_message_id@ is not specified. Unique identifier for the target chat.
-  , getGameHighScoresRequestMessageId       :: Maybe MessageId -- ^ Required if @inline_message_id@ is not specified. Identifier of the sent message.
-  , getGameHighScoresRequestInlineMessageId :: Maybe MessageId -- ^ Required if @chat_id@ and @message_id@ are not specified. Identifier of the inline message.
+  { getGameHighScoresUserId          :: UserId          -- ^ Target user id.
+  , getGameHighScoresChatId          :: Maybe ChatId    -- ^ Required if @inline_message_id@ is not specified. Unique identifier for the target chat.
+  , getGameHighScoresMessageId       :: Maybe MessageId -- ^ Required if @inline_message_id@ is not specified. Identifier of the sent message.
+  , getGameHighScoresInlineMessageId :: Maybe MessageId -- ^ Required if @chat_id@ and @message_id@ are not specified. Identifier of the inline message.
   }
   deriving (Generic, Show)
 

--- a/src/Telegram/Bot/API/Methods.hs
+++ b/src/Telegram/Bot/API/Methods.hs
@@ -10,173 +10,68 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Methods
-  ( AnswerCallbackQuery
-  , ApproveChatJoinRequest
-  , BanChatMember
-  , BanChatSenderChat
-  , CopyMessage
-  , CreateChatInviteLink
-  , DeclineChatJoinRequest
-  , DeleteChatPhoto
-  , DeleteChatStickerSet
-  , DeleteMessage
-  , DeleteMyCommands
-  , EditChatInviteLink
-  , EditMessageLiveLocation
-  , ExportChatInviteLink
-  , ForwardMessage
-  , GetChat
-  , GetChatAdministrators
-  , GetChatMember
-  , GetChatMemberCount
-  , GetChatMenuButton
-  , GetFile
-  , GetMe
-  , GetMyCommands
-  , GetMyDefaultAdministratorRights
-  , GetUserProfilePhotos
-  , LeaveChat
-  , PinChatMessage
-  , PromoteChatMember
-  , RestrictChatMember
-  , RevokeChatInviteLink
-  , SendAnimationContent
-  , SendAnimationLink
-  , SendAudioContent
-  , SendAudioLink
-  , SendChatAction
-  , SendContact
-  , SendDice
-  , SendDocumentContent
-  , SendDocumentLink
-  , SendLocation
-  , SendMediaGroup
-  , SendMessage
-  , SendPhotoContent
-  , SendPhotoLink
-  , SendPoll
-  , SendVenue
-  , SendVideoContent
-  , SendVideoLink
-  , SendVideoNoteContent
-  , SendVideoNoteLink
-  , SendVoiceContent
-  , SendVoiceLink
-  , SetChatAdministratorCustomTitle
-  , SetChatDescription
-  , SetChatMenuButton
-  , SetChatPermissions
-  , SetChatPhoto
-  , SetChatStickerSet
-  , SetChatTitle
-  , SetMyCommands
-  , SetMyDefaultAdministratorRights
-  , StopMessageLiveLocation
-  , UnbanChatMember
-  , UnbanChatSenderChat
-  , UnpinAllChatMessages
-  , UnpinChatMessage
-
-  , ParseMode (..)
-  , SomeReplyMarkup (..)
-
-  , AnswerCallbackQueryRequest (..)
-  , BanChatMemberRequest (..)
-  , CopyMessageRequest (..)
-  , CreateChatInviteLinkRequest (..)
-  , DeleteMyCommandsRequest (..)
-  , EditChatInviteLinkRequest (..)
-  , EditMessageLiveLocationRequest (..)
-  , ForwardMessageRequest (..)
-  , GetChatMenuButtonRequest (..)
-  , GetMyCommandsRequest (..)
-  , GetMyDefaultAdministratorRightsRequest (..)
-  , GetUserProfilePhotosRequest (..)
-  , PinChatMessageRequest (..)
-  , PromoteChatMemberRequest (..)
-  , RestrictChatMemberRequest (..)
-  , SendAnimationRequest (..)
-  , SendAudioRequest (..)
-  , SendContactRequest (..)
-  , SendDiceRequest (..)
-  , SendDocumentRequest (..)
-  , SendLocationRequest (..)
-  , SendMediaGroupRequest (..)
-  , SendMessageRequest (..)
-  , SendPhotoRequest (..)
-  , SendPollRequest (..)
-  , SendVenueRequest (..)
-  , SendVideoRequest (..)
-  , SendVideoNoteRequest (..)
-  , SendVoiceRequest (..)
-  , SetChatAdministratorCustomTitleRequest (..)
-  , SetChatMenuButtonRequest (..)
-  , SetChatPermissionsRequest (..)
-  , SetChatPhotoRequest (..)
-  , SetMyCommandsRequest (..)
-  , SetMyDefaultAdministratorRightsRequest (..)
-  , StopMessageLiveLocationRequest (..)
-  , UnbanChatMemberRequest (..)
-
-  , answerCallbackQuery
-  , approveChatJoinRequest
-  , banChatMember
-  , banChatSenderChat
-  , copyMessage
-  , createChatInviteLink
-  , declineChatJoinRequest
-  , deleteChatPhoto
-  , deleteChatStickerSet
-  , deleteMessage
-  , deleteMyCommands
-  , editChatInviteLink
-  , editMessageLiveLocation
-  , exportChatInviteLink
-  , forwardMessage
-  , getChat
-  , getChatAdministrators
-  , getChatMember
-  , getChatMemberCount
-  , getChatMenuButton
-  , getFile
-  , getMe
-  , getMyCommands
-  , getMyDefaultAdministratorRights
-  , getUserProfilePhotos
-  , leaveChat
-  , pinChatMessage
-  , promoteChatMember
-  , restrictChatMember
-  , revokeChatInviteLink
-  , sendAnimation
-  , sendAudio
-  , sendChatAction
-  , sendContact
-  , sendDice
-  , sendDocument
-  , sendLocation
-  , sendMediaGroup
-  , sendMessage
-  , sendPhoto
-  , sendPoll
-  , sendVenue
-  , sendVideo
-  , sendVideoNote
-  , sendVoice
-  , setChatAdministratorCustomTitle
-  , setChatDescription
-  , setChatMenuButton
-  , setChatPermissions
-  , setChatPhoto
-  , setChatStickerSet
-  , setChatTitle
-  , setMyCommands
-  , setMyDefaultAdministratorRights
-  , stopMessageLiveLocation
-  , unbanChatMember
-  , unbanChatSenderChat
-  , unpinAllChatMessages
-  , unpinChatMessage
+  ( module Telegram.Bot.API.Types.ParseMode
+  , module Telegram.Bot.API.Types.SomeReplyMarkup
+  
+  , module Telegram.Bot.API.Methods.AnswerCallbackQuery
+  , module Telegram.Bot.API.Methods.ApproveChatJoinRequest
+  , module Telegram.Bot.API.Methods.BanChatMember
+  , module Telegram.Bot.API.Methods.BanChatSenderChat
+  , module Telegram.Bot.API.Methods.CopyMessage
+  , module Telegram.Bot.API.Methods.CreateChatInviteLink
+  , module Telegram.Bot.API.Methods.DeclineChatJoinRequest
+  , module Telegram.Bot.API.Methods.DeleteChatPhoto
+  , module Telegram.Bot.API.Methods.DeleteChatStickerSet
+  , module Telegram.Bot.API.Methods.DeleteMessage
+  , module Telegram.Bot.API.Methods.DeleteMyCommands
+  , module Telegram.Bot.API.Methods.EditChatInviteLink
+  , module Telegram.Bot.API.Methods.EditMessageLiveLocation
+  , module Telegram.Bot.API.Methods.ExportChatInviteLink
+  , module Telegram.Bot.API.Methods.ForwardMessage
+  , module Telegram.Bot.API.Methods.GetChat
+  , module Telegram.Bot.API.Methods.GetChatAdministrators
+  , module Telegram.Bot.API.Methods.GetChatMember
+  , module Telegram.Bot.API.Methods.GetChatMemberCount
+  , module Telegram.Bot.API.Methods.GetChatMenuButton
+  , module Telegram.Bot.API.Methods.GetFile
+  , module Telegram.Bot.API.Methods.GetMe
+  , module Telegram.Bot.API.Methods.GetMyCommands
+  , module Telegram.Bot.API.Methods.GetMyDefaultAdministratorRights
+  , module Telegram.Bot.API.Methods.GetUserProfilePhotos
+  , module Telegram.Bot.API.Methods.LeaveChat
+  , module Telegram.Bot.API.Methods.PinChatMessage
+  , module Telegram.Bot.API.Methods.PromoteChatMember
+  , module Telegram.Bot.API.Methods.RestrictChatMember
+  , module Telegram.Bot.API.Methods.RevokeChatInviteLink
+  , module Telegram.Bot.API.Methods.SendAnimation
+  , module Telegram.Bot.API.Methods.SendAudio
+  , module Telegram.Bot.API.Methods.SendChatAction
+  , module Telegram.Bot.API.Methods.SendContact
+  , module Telegram.Bot.API.Methods.SendDice
+  , module Telegram.Bot.API.Methods.SendDocument
+  , module Telegram.Bot.API.Methods.SendLocation
+  , module Telegram.Bot.API.Methods.SendMediaGroup
+  , module Telegram.Bot.API.Methods.SendMessage
+  , module Telegram.Bot.API.Methods.SendPhoto
+  , module Telegram.Bot.API.Methods.SendPoll
+  , module Telegram.Bot.API.Methods.SendVenue
+  , module Telegram.Bot.API.Methods.SendVideo
+  , module Telegram.Bot.API.Methods.SendVideoNote
+  , module Telegram.Bot.API.Methods.SendVoice
+  , module Telegram.Bot.API.Methods.SetChatAdministratorCustomTitle
+  , module Telegram.Bot.API.Methods.SetChatDescription
+  , module Telegram.Bot.API.Methods.SetChatMenuButton
+  , module Telegram.Bot.API.Methods.SetChatPermissions
+  , module Telegram.Bot.API.Methods.SetChatPhoto
+  , module Telegram.Bot.API.Methods.SetChatStickerSet
+  , module Telegram.Bot.API.Methods.SetChatTitle
+  , module Telegram.Bot.API.Methods.SetMyCommands
+  , module Telegram.Bot.API.Methods.SetMyDefaultAdministratorRights
+  , module Telegram.Bot.API.Methods.StopMessageLiveLocation
+  , module Telegram.Bot.API.Methods.UnbanChatMember
+  , module Telegram.Bot.API.Methods.UnbanChatSenderChat
+  , module Telegram.Bot.API.Methods.UnpinAllChatMessages
+  , module Telegram.Bot.API.Methods.UnpinChatMessage
   ) where
 
 import Telegram.Bot.API.Types.ParseMode

--- a/src/Telegram/Bot/API/Methods.hs
+++ b/src/Telegram/Bot/API/Methods.hs
@@ -9,1724 +9,235 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Telegram.Bot.API.Methods where
-
-import Control.Monad.IO.Class
-import Data.Aeson
-import Data.Aeson.Text
-import Data.Bool
-import Data.Proxy
-import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
-import GHC.Generics (Generic)
-import Servant.API
-import Servant.Client hiding (Response)
-import Servant.Multipart.API
-import Servant.Multipart.Client
-import System.FilePath
-
-import Telegram.Bot.API.Internal.Utils
-import Telegram.Bot.API.MakingRequests
-import Telegram.Bot.API.Types
-import Data.Maybe (catMaybes)
-import Data.Functor ((<&>))
-
--- * Available methods
-
--- ** 'getMe'
-
-type GetMe = "getMe" :> Get '[JSON] (Response User)
-
--- | A simple method for testing your bot's auth token.
--- Requires no parameters.
--- Returns basic information about the bot in form of a 'User' object.
-getMe :: ClientM (Response User)
-getMe = client (Proxy @GetMe)
-
--- ** 'deleteMessage'
-
--- | Notice that deleting by POST method was bugged, so we use GET
-type DeleteMessage = "deleteMessage"
-  :> RequiredQueryParam "chat_id" ChatId
-  :> RequiredQueryParam "message_id" MessageId
-  :> Get '[JSON] (Response Bool)
-
--- | Use this method to delete message in chat.
--- On success, the sent Bool is returned.
-deleteMessage :: ChatId -> MessageId -> ClientM (Response Bool)
-deleteMessage = client (Proxy @DeleteMessage)
-
--- ** 'sendMessage'
-
-type SendMessage
-  = "sendMessage" :> ReqBody '[JSON] SendMessageRequest :> Post '[JSON] (Response Message)
-
--- | Use this method to send text messages.
--- On success, the sent 'Message' is returned.
-sendMessage :: SendMessageRequest -> ClientM (Response Message)
-sendMessage = client (Proxy @SendMessage)
-
--- ** 'forwardMessage'
-type ForwardMessage
-  = "forwardMessage" :> ReqBody '[JSON] ForwardMessageRequest :> Post '[JSON] (Response Message)
-
--- | Use this method to forward messages of any kind.
--- On success, the sent 'Message' is returned.
-
-forwardMessage :: ForwardMessageRequest -> ClientM (Response Message)
-forwardMessage = client (Proxy @ForwardMessage)
-
--- | Additional interface options.
--- A JSON-serialized object for an inline keyboard, custom reply keyboard,
--- instructions to remove reply keyboard or to force a reply from the user.
-data SomeReplyMarkup
-  = SomeInlineKeyboardMarkup InlineKeyboardMarkup
-  | SomeReplyKeyboardMarkup  ReplyKeyboardMarkup
-  | SomeReplyKeyboardRemove  ReplyKeyboardRemove
-  | SomeForceReply           ForceReply
-  deriving (Generic)
-
-instance ToJSON   SomeReplyMarkup where toJSON = genericSomeToJSON
-instance FromJSON SomeReplyMarkup where parseJSON = genericSomeParseJSON
-
-data ParseMode
-  = Markdown
-  | HTML
-  | MarkdownV2
-  deriving (Generic)
-
-instance ToJSON   ParseMode
-instance FromJSON ParseMode
-
--- | Request parameters for 'sendMessage'.
-data SendMessageRequest = SendMessageRequest
-  { sendMessageChatId                :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername@).
-  , sendMessageMessageThreadId       :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendMessageText                  :: Text -- ^ Text of the message to be sent.
-  , sendMessageParseMode             :: Maybe ParseMode -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-  , sendMessageEntities              :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in message text, which can be specified instead of /parse_mode/.
-  , sendMessageDisableWebPagePreview :: Maybe Bool -- ^ Disables link previews for links in this message.
-  , sendMessageDisableNotification   :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendMessageProtectContent        :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.
-  , sendMessageReplyToMessageId      :: Maybe MessageId -- ^ If the message is a reply, ID of the original message.
-  , sendMessageAllowSendingWithoutReply :: Maybe Bool -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found.
-  , sendMessageReplyMarkup           :: Maybe SomeReplyMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  } deriving (Generic)
-
-instance ToJSON   SendMessageRequest where toJSON = gtoJSON
-instance FromJSON SendMessageRequest where parseJSON = gparseJSON
-
--- | Request parameters for 'forwardMessage'.
-data ForwardMessageRequest = ForwardMessageRequest
-  { forwardMessageChatId              :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername).
-  , forwardMessageMessageThreadId     :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , forwardMessageFromChatId          :: SomeChatId -- ^ Unique identifier for the chat where the original message was sent (or channel username in the format @\@channelusername).
-  , forwardMessageDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , forwardMessageProtectContent      :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.
-  , forwardMessageMessageId           :: MessageId  -- ^ Message identifier in the chat specified in from_chat_id.
-  } deriving (Generic)
-
-instance ToJSON   ForwardMessageRequest where toJSON = gtoJSON
-instance FromJSON ForwardMessageRequest where parseJSON = gparseJSON
-
--- ** 'sendMessage'
-type SendDocumentContent
-  = "sendDocument"
-  :> MultipartForm Tmp SendDocumentRequest
-  :> Post '[JSON] (Response Message)
-
-type SendDocumentLink
-  = "sendDocument"
-  :> ReqBody '[JSON] SendDocumentRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send text messages.
--- On success, the sent 'Message' is returned.
---
--- <https:\/\/core.telegram.org\/bots\/api#senddocument>
-sendDocument :: SendDocumentRequest -> ClientM (Response Message)
-sendDocument r = do
-  case sendDocumentDocument r of
-    DocumentFile{} -> do
-      boundary <- liftIO genBoundary
-      client (Proxy @SendDocumentContent) (boundary, r)
-    _ -> client (Proxy @SendDocumentLink) r
-
--- | Request parameters for 'sendDocument'
-data SendDocumentRequest = SendDocumentRequest
-  { sendDocumentChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername@).
-  , sendDocumentMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendDocumentDocument :: DocumentFile -- ^ Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data
-  , sendDocumentThumb :: Maybe FilePath -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>
-  , sendDocumentCaption :: Maybe Text -- ^ Document caption (may also be used when resending documents by file_id), 0-1024 characters after entities parsing
-  , sendDocumentParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-  , sendDocumentCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of /parse_mode/.
-  , sendDocumentDisableContentTypeDetection :: Maybe Bool -- ^ Disables automatic server-side content type detection for files uploaded using @multipart/form-data@.
-  , sendDocumentDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendDocumentProtectContent      :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.  
-  , sendDocumentReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message.
-  , sendDocumentAllowSendingWithoutReply :: Maybe Bool -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found.
-  , sendDocumentReplyMarkup :: Maybe SomeReplyMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
-
-newtype DocumentFile = MakeDocumentFile InputFile
-  deriving newtype ToJSON
-
-pattern DocumentFileId :: FileId -> DocumentFile
-pattern DocumentFileId x = MakeDocumentFile (InputFileId x)
-
-pattern DocumentUrl :: Text -> DocumentFile
-pattern DocumentUrl x = MakeDocumentFile (FileUrl x)
-
-pattern DocumentFile :: FilePath -> ContentType -> DocumentFile
-pattern DocumentFile x y = MakeDocumentFile (InputFile x y)
-
-
-instance ToMultipart Tmp SendDocumentRequest where
-  toMultipart SendDocumentRequest{..} = MultipartData fields files where
-    fields =
-      [ Input "document" $ T.pack $ "attach://file"
-      , Input "chat_id" $ case sendDocumentChatId of
-          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
-          SomeChatUsername txt -> txt
-      ] <>
-      (   (maybe id (\t -> ((Input "message_thread_id") (T.pack $ show t):)) sendDocumentMessageThreadId)
-        $ (maybe id (\_ -> ((Input "thumb" "attach://thumb"):)) sendDocumentThumb)
-        $ (maybe id (\t -> ((Input "caption" t):)) sendDocumentCaption)
-        $ (maybe id (\t -> ((Input "parse_mode" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentParseMode)
-        $ (maybe id (\t -> ((Input "caption_entities" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentCaptionEntities)
-        $ (maybe id (\t -> ((Input "disable_notification" (bool "false" "true" t)):)) sendDocumentDisableNotification)
-        $ (maybe id (\t -> ((Input "disable_content_type_detection" (bool "false" "true" t)):)) sendDocumentDisableContentTypeDetection)
-        $ (maybe id (\t -> ((Input "protect_content" (bool "false" "true" t)):)) sendDocumentProtectContent)
-        $ (maybe id (\t -> ((Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentReplyToMessageId)
-        $ (maybe id (\t -> ((Input "allow_sending_without_reply" (bool "false" "true" t)):)) sendDocumentAllowSendingWithoutReply)
-        $ (maybe id (\t -> ((Input "reply_markup" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentReplyMarkup)
-        [])
-    files
-      = (FileData "file" (T.pack $ takeFileName path) ct path)
-      : maybe [] (\t -> [FileData "thumb" (T.pack $ takeFileName t) "image/jpeg" t]) sendDocumentThumb
-
-    DocumentFile path ct = sendDocumentDocument
-
-
-instance ToJSON   SendDocumentRequest where toJSON = gtoJSON
-
--- | Generate send document structure.
-toSendDocument :: SomeChatId -> DocumentFile -> SendDocumentRequest
-toSendDocument ch df = SendDocumentRequest
-  { sendDocumentChatId = ch
-  , sendDocumentMessageThreadId = Nothing
-  , sendDocumentDocument = df
-  , sendDocumentThumb = Nothing
-  , sendDocumentCaption = Nothing
-  , sendDocumentParseMode = Nothing
-  , sendDocumentCaptionEntities =  Nothing
-  , sendDocumentDisableContentTypeDetection = Nothing
-  , sendDocumentDisableNotification = Nothing
-  , sendDocumentProtectContent = Nothing
-  , sendDocumentReplyToMessageId = Nothing
-  , sendDocumentAllowSendingWithoutReply = Nothing
-  , sendDocumentReplyMarkup = Nothing
-  }
-
--- ** 'getFile'
-type GetFile
-  = "getFile"
-  :> RequiredQueryParam "file_id" FileId
-  :> Get '[JSON] (Response File)
-
-getFile :: FileId -> ClientM (Response File)
-getFile = client (Proxy @GetFile)
-
--- ** 'sendPhoto'
-type SendPhotoContent
-  = "sendPhoto"
-  :> MultipartForm Tmp SendPhotoRequest
-  :> Post '[JSON] (Response Message)
-
-type SendPhotoLink
-  = "sendPhoto"
-  :> ReqBody '[JSON] SendPhotoRequest
-  :> Post '[JSON] (Response Message)
-
-
-
-newtype PhotoFile = MakePhotoFile InputFile
-  deriving newtype ToJSON
-
-pattern PhotoFileId :: FileId -> PhotoFile
-pattern PhotoFileId x = MakePhotoFile (InputFileId x)
-
-pattern PhotoUrl :: Text -> PhotoFile
-pattern PhotoUrl x = MakePhotoFile (FileUrl x)
-
-pattern PhotoFile :: FilePath -> ContentType -> PhotoFile
-pattern PhotoFile x y = MakePhotoFile (InputFile x y)
-
-
--- | Request parameters for 'sendPhoto'
-data SendPhotoRequest = SendPhotoRequest
-  { sendPhotoChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername@).
-  , sendPhotoMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendPhotoPhoto :: PhotoFile -- ^ Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data
-  , sendPhotoThumb :: Maybe FilePath -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>
-  , sendPhotoCaption :: Maybe Text -- ^ Photo caption (may also be used when resending Photos by file_id), 0-1024 characters after entities parsing
-  , sendPhotoParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-  , sendPhotoCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of /parse_mode/.
-  , sendPhotoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the photo needs to be covered with a spoiler animation.
-  , sendPhotoDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendPhotoProtectContent      :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.  
-  , sendPhotoReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message.
-  , sendPhotoAllowSendingWithoutReply :: Maybe Bool -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found.
-  , sendPhotoReplyMarkup :: Maybe SomeReplyMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
-instance ToMultipart Tmp SendPhotoRequest where
-  toMultipart SendPhotoRequest{..} = MultipartData fields files where
-    fields =
-      [ Input "photo" $ T.pack $ "attach://file"
-      , Input "chat_id" $ case sendPhotoChatId of
-          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
-          SomeChatUsername txt -> txt
-      ] <>
-      (   (maybe id (\t -> ((Input "message_thread_id" (T.pack $ show t)):)) sendPhotoMessageThreadId)
-        $ (maybe id (\_ -> ((Input "thumb" "attach://thumb"):)) sendPhotoThumb)
-        $ (maybe id (\t -> ((Input "caption" t):)) sendPhotoCaption)
-        $ (maybe id (\t -> ((Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)):)) sendPhotoParseMode)
-        $ (maybe id (\t -> ((Input "caption_entities" (TL.toStrict $ encodeToLazyText t)):)) sendPhotoCaptionEntities)
-        $ (maybe id (\t -> ((Input "has_spoiler" (bool "false" "true" t)):)) sendPhotoHasSpoiler)
-        $ (maybe id (\t -> ((Input "disable_notification" (bool "false" "true" t)):)) sendPhotoDisableNotification)
-        $ (maybe id (\t -> ((Input "protect_content" (bool "false" "true" t)):)) sendPhotoProtectContent)
-        $ (maybe id (\t -> ((Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)):)) sendPhotoReplyToMessageId)
-        $ (maybe id (\t -> ((Input "allow_sending_without_reply" (bool "false" "true" t)):)) sendPhotoAllowSendingWithoutReply)
-        $ (maybe id (\t -> ((Input "reply_markup" (TL.toStrict $ encodeToLazyText t)):)) sendPhotoReplyMarkup)
-        [])
-    files
-      = (FileData "file" (T.pack $ takeFileName path) ct path)
-      : maybe [] (\t -> [FileData "thumb" (T.pack $ takeFileName t) "image/jpeg" t]) sendPhotoThumb
-
-    PhotoFile path ct = sendPhotoPhoto
-
-instance ToJSON SendPhotoRequest where toJSON = gtoJSON
-
--- | Use this method to send photos.
--- On success, the sent 'Message' is returned.
---
--- <https:\/\/core.telegram.org\/bots\/api#sendphoto>
-sendPhoto :: SendPhotoRequest -> ClientM (Response Message)
-sendPhoto r = do
-  case sendPhotoPhoto r of
-    PhotoFile{} -> do
-      boundary <- liftIO genBoundary
-      client (Proxy @SendPhotoContent) (boundary, r)
-    _ -> client (Proxy @SendPhotoLink) r
-
--- | Request parameters for 'copyMessage'.
-data CopyMessageRequest = CopyMessageRequest
-  { copyMessageChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , copyMessageMessageThreadId :: Maybe Message -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , copyMessageFromChatId :: SomeChatId -- ^ Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
-  , copyMessageMessageId :: MessageId -- ^ Message identifier in the chat specified in from_chat_id
-  , copyMessageCaption :: Maybe Text -- ^ New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept
-  , copyMessageParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-  , copyMessageCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
-  , copyMessageDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , copyMessageProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
-  , copyMessageReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , copyMessageAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , copyMessageReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
--- | Request parameters for 'sendAudio'.
-data SendAudioRequest = SendAudioRequest
-  { sendAudioChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendAudioMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendAudioAudio :: InputFile -- ^ Audio to send. Pass a file_id as String to send an audio that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a audio from the Internet, or upload a new audio using multipart/form-data. More info on Sending Files »
-  , sendAudioDuration :: Maybe Int -- ^ Duration of sent audio in seconds
-  , sendAudioPerformer :: Maybe Text -- ^ Performer
-  , sendAudioTitle :: Maybe Text -- ^ Track name
-  , sendAudioThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
-  , sendAudioCaption :: Maybe Text -- ^ Audio caption (may also be used when resending audios by file_id), 0-1024 characters after entities parsing
-  , sendAudioParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-  , sendAudioCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
-  , sendAudioDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendAudioProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
-  , sendAudioReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendAudioAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendAudioReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
-instance ToJSON SendAudioRequest where toJSON = gtoJSON
-
-instance ToMultipart Tmp SendAudioRequest where
-  toMultipart SendAudioRequest{..} =
-    maybe id (makeFile "thumb") sendAudioThumb $
-    makeFile "audio" sendAudioAudio $
-    MultipartData fields [] where
-    fields =
-      [ Input "chat_id" $ case sendAudioChatId of
-          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
-          SomeChatUsername txt -> txt
-      ] <> catMaybes
-      [ sendAudioMessageThreadId <&>
-        \t -> Input "message_thread_id" (T.pack $ show t)
-      , sendAudioCaption <&>
-        \t -> Input "caption" t
-      , sendAudioParseMode <&>
-        \t -> Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)
-      , sendAudioCaptionEntities <&>
-        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
-      , sendAudioDuration <&>
-        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
-      , sendAudioPerformer <&>
-        \t -> Input "performer" t
-      , sendAudioTitle <&>
-        \t -> Input "title" (TL.toStrict $ encodeToLazyText t)
-      , sendAudioDisableNotification <&>
-        \t -> Input "disable_notification" (bool "false" "true" t)
-      , sendAudioProtectContent <&>
-        \t -> Input "protect_content" (bool "false" "true" t)
-      , sendAudioReplyToMessageId <&>
-        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
-      , sendAudioAllowSendingWithoutReply <&>
-        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
-      , sendAudioReplyMarkup <&>
-        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
-      ]
-
-type SendAudioContent
-  = "sendAudio"
-  :> MultipartForm Tmp SendAudioRequest
-  :> Post '[JSON] (Response Message)
-
-type SendAudioLink
-  = "sendAudio"
-  :> ReqBody '[JSON] SendAudioRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send audio files, if
---   you want Telegram clients to display them
---   in the music player. Your audio must be in
---   the .MP3 or .M4A format. On success, the sent
---   Message is returned. Bots can currently send
---   audio files of up to 50 MB in size, this limit
---   may be changed in the future.
---
---   For sending voice messages, use the sendVoice method instead.
-sendAudio :: SendAudioRequest ->  ClientM (Response Message)
-sendAudio r = case (sendAudioAudio r, sendAudioThumb r) of
-  (InputFile{}, _) -> do
-    boundary <- liftIO genBoundary
-    client (Proxy @SendAudioContent) (boundary, r)
-  (_, Just InputFile{}) -> do
-    boundary <- liftIO genBoundary
-    client (Proxy @SendAudioContent) (boundary, r)
-  _ ->  client (Proxy @SendAudioLink) r
-
--- | Request parameters for 'sendVideo'.
-data SendVideoRequest = SendVideoRequest
-  { sendVideoChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , sendVideoMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendVideoVideo :: InputFile -- ^ Video to send. Pass a file_id as String to send an video that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a video from the Internet, or upload a new video using multipart/form-data. More info on Sending Files »
-  , sendVideoDuration :: Maybe Int -- ^ Duration of sent video in seconds
-  , sendVideoWidth :: Maybe Int -- ^ Video width
-  , sendVideoHeight :: Maybe Int -- ^ Video height
-  , sendVideoThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
-  , sendVideoCaption :: Maybe Text -- ^ Video caption (may also be used when resending videos by file_id), 0-1024 characters after entities parsing
-  , sendVideoParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-  , sendVideoCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
-  , sendVideoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
-  , sendVideoSupportsStreaming :: Maybe Bool -- ^ Pass True, if the uploaded video is suitable for streaming
-  , sendVideoDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendVideoProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.
-  , sendVideoReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendVideoAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendVideoReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
-instance ToJSON SendVideoRequest where toJSON = gtoJSON
-
-instance ToMultipart Tmp SendVideoRequest where
-  toMultipart SendVideoRequest{..} =
-    maybe id (makeFile "thumb") sendVideoThumb $
-    makeFile "video" sendVideoVideo $
-    MultipartData fields [] where
-    fields =
-      [ Input "chat_id" $ case sendVideoChatId of
-          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
-          SomeChatUsername txt -> txt
-      ] <> catMaybes
-      [ sendVideoMessageThreadId <&>
-        \t -> Input "message_thread_id" (T.pack $ show t)
-      , sendVideoCaption <&>
-        \t -> Input "caption" t
-      , sendVideoParseMode <&>
-        \t -> Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)
-      , sendVideoCaptionEntities <&>
-        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
-      , sendVideoHasSpoiler <&>
-        \t -> Input "has_spoiler" (bool "false" "true" t)
-      , sendVideoDuration <&>
-        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
-      , sendVideoWidth <&>
-        \t -> Input "width" (TL.toStrict $ encodeToLazyText t)
-      , sendVideoHeight <&>
-        \t -> Input "height" (TL.toStrict $ encodeToLazyText t)
-      , sendVideoDisableNotification <&>
-        \t -> Input "disable_notification" (bool "false" "true" t)
-      , sendVideoSupportsStreaming <&>
-        \t -> Input "supports_streaming" (bool "false" "true" t)
-      , sendVideoProtectContent <&>
-        \t -> Input "protect_content" (bool "false" "true" t)
-      , sendVideoReplyToMessageId <&>
-        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
-      , sendVideoAllowSendingWithoutReply <&>
-        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
-      , sendVideoReplyMarkup <&>
-        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
-      ]
-
-type SendVideoContent
-  = "sendVideo"
-  :> MultipartForm Tmp SendVideoRequest
-  :> Post '[JSON] (Response Message)
-
-type SendVideoLink
-  = "sendVideo"
-  :> ReqBody '[JSON] SendVideoRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send video files,
---   Telegram clients support mp4 videos
---   (other formats may be sent as Document).
---   On success, the sent Message is returned.
---   Bots can currently send video files of up
---   to 50 MB in size, this limit may be changed in the future.
-sendVideo :: SendVideoRequest ->  ClientM (Response Message)
-sendVideo r = case (sendVideoVideo r, sendVideoThumb r) of
-  (InputFile{}, _) -> do
-    boundary <- liftIO genBoundary
-    client (Proxy @SendVideoContent) (boundary, r)
-  (_, Just InputFile{}) -> do
-    boundary <- liftIO genBoundary
-    client (Proxy @SendVideoContent) (boundary, r)
-  _ ->  client (Proxy @SendVideoLink) r
-
--- | Request parameters for 'sendAnimation'.
-data SendAnimationRequest = SendAnimationRequest
-  { sendAnimationChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , sendAnimationMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendAnimationAnimation :: InputFile -- ^ Animation to send. Pass a file_id as String to send an animation that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an animation from the Internet, or upload a new animation using multipart/form-data. More info on Sending Files »
-  , sendAnimationDuration :: Maybe Int -- ^ Duration of sent animation in seconds
-  , sendAnimationWidth :: Maybe Int -- ^ Animation width
-  , sendAnimationHeight :: Maybe Int -- ^ Animation height
-  , sendAnimationThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
-  , sendAnimationCaption :: Maybe Text -- ^ Animation caption (may also be used when resending animation by file_id), 0-1024 characters after entities parsing
-  , sendAnimationParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-  , sendAnimationCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
-  , sendAnimationHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the animation needs to be covered with a spoiler animation.
-  , sendAnimationDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendAnimationProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.
-  , sendAnimationReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message.
-  , sendAnimationAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found.
-  , sendAnimationReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
-instance ToJSON SendAnimationRequest where toJSON = gtoJSON
-
-instance ToMultipart Tmp SendAnimationRequest where
-  toMultipart SendAnimationRequest{..} =
-    maybe id (makeFile "thumb") sendAnimationThumb $
-    makeFile "animation" sendAnimationAnimation $
-    MultipartData fields [] where
-    fields =
-      [ Input "chat_id" $ case sendAnimationChatId of
-          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
-          SomeChatUsername txt -> txt
-      ] <> catMaybes
-      [ sendAnimationMessageThreadId <&>
-        \t -> Input "message_thread_id" (T.pack $ show t)
-      , sendAnimationCaption <&>
-        \t -> Input "caption" t
-      , sendAnimationParseMode <&>
-        \t -> Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)
-      , sendAnimationCaptionEntities <&>
-        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
-      , sendAnimationHasSpoiler <&>
-        \t -> Input "has_spoiler" (bool "false" "true" t)
-      , sendAnimationDuration <&>
-        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
-      , sendAnimationWidth <&>
-        \t -> Input "width" (TL.toStrict $ encodeToLazyText t)
-      , sendAnimationHeight <&>
-        \t -> Input "height" (TL.toStrict $ encodeToLazyText t)
-      , sendAnimationDisableNotification <&>
-        \t -> Input "disable_notification" (bool "false" "true" t)
-      , sendAnimationProtectContent <&>
-        \t -> Input "protect_content" (bool "false" "true" t)
-      , sendAnimationReplyToMessageId <&>
-        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
-      , sendAnimationAllowSendingWithoutReply <&>
-        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
-      , sendAnimationReplyMarkup <&>
-        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
-      ]
-
-type SendAnimationContent
-  = "sendAnimation"
-  :> MultipartForm Tmp SendAnimationRequest
-  :> Post '[JSON] (Response Message)
-
-type SendAnimationLink
-  = "sendAnimation"
-  :> ReqBody '[JSON] SendAnimationRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send animation files
---   (GIF or H.264/MPEG-4 AVC video without sound).
---   On success, the sent Message is returned. Bots
---   can currently send animation files of up to 50
---   MB in size, this limit may be changed in the future.
-sendAnimation :: SendAnimationRequest ->  ClientM (Response Message)
-sendAnimation r = case (sendAnimationAnimation r, sendAnimationThumb r) of
-  (InputFile{}, _) -> do
-    boundary <- liftIO genBoundary
-    client (Proxy @SendAnimationContent) (boundary, r)
-  (_, Just InputFile{}) -> do
-    boundary <- liftIO genBoundary
-    client (Proxy @SendAnimationContent) (boundary, r)
-  _ ->  client (Proxy @SendAnimationLink) r
-
--- | Request parameters for 'sendVoice'.
-data SendVoiceRequest = SendVoiceRequest
-  { sendVoiceChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendVoiceMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendVoiceVoice :: InputFile -- ^ Audio file to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More info on Sending Files »
-  , sendVoiceCaption :: Maybe Text -- ^ Voice message caption, 0-1024 characters after entities parsing
-  , sendVoiceParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-  , sendVoiceCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
-  , sendVoiceDuration :: Maybe Int -- ^ Duration of the voice message in seconds
-  , sendVoiceDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendVoiceProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
-  , sendVoiceReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendVoiceAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendVoiceReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
-instance ToJSON SendVoiceRequest where toJSON = gtoJSON
-
-instance ToMultipart Tmp SendVoiceRequest where
-  toMultipart SendVoiceRequest{..} =
-    makeFile "voice" sendVoiceVoice $
-    MultipartData fields [] where
-    fields =
-      [ Input "chat_id" $ case sendVoiceChatId of
-          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
-          SomeChatUsername txt -> txt
-      ] <> catMaybes
-      [ sendVoiceMessageThreadId <&>
-        \t -> Input "message_thread_id" (T.pack $ show t)
-      , sendVoiceCaption <&>
-        \t -> Input "caption" t
-      , sendVoiceParseMode <&>
-        \t -> Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)
-      , sendVoiceCaptionEntities <&>
-        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
-      , sendVoiceDuration <&>
-        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
-      , sendVoiceProtectContent <&>
-        \t -> Input "protect_content" (bool "false" "true" t)
-      , sendVoiceDisableNotification <&>
-        \t -> Input "disable_notification" (bool "false" "true" t)
-      , sendVoiceReplyToMessageId <&>
-        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
-      , sendVoiceAllowSendingWithoutReply <&>
-        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
-      , sendVoiceReplyMarkup <&>
-        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
-      ]
-
-type SendVoiceContent
-  = "sendVoice"
-  :> MultipartForm Tmp SendVoiceRequest
-  :> Post '[JSON] (Response Message)
-
-type SendVoiceLink
-  = "sendVoice"
-  :> ReqBody '[JSON] SendVoiceRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send audio files,
---   if you want Telegram clients to display
---   the file as a playable voice message. For
---   this to work, your audio must be in an .OGG
---   file encoded with OPUS (other formats may be
---   sent as Audio or Document).
---   On success, the sent Message is returned.
---   Bots can currently send voice messages of up
---   to 50 MB in size, this limit may be changed in the future.
-sendVoice :: SendVoiceRequest ->  ClientM (Response Message)
-sendVoice r = case sendVoiceVoice r of
-  InputFile{} -> do
-    boundary <- liftIO genBoundary
-    client (Proxy @SendVoiceContent) (boundary, r)
-  _ ->  client (Proxy @SendVoiceLink) r
-
--- | Request parameters for 'sendVideoNote'.
-data SendVideoNoteRequest = SendVideoNoteRequest
-  { sendVideoNoteChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendVideoNoteMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendVideoNoteVideoNote :: InputFile -- ^ Video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended) or upload a new video using multipart/form-data. More info on Sending Files ». Sending video notes by a URL is currently unsupported
-  , sendVideoNoteDuration :: Maybe Int -- ^ Duration of sent video in seconds
-  , sendVideoNoteLength :: Maybe Int -- ^ Video width and height, i.e. diameter of the video message
-  , sendVideoNoteThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
-  , sendVideoNoteDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendVideoNoteProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
-  , sendVideoNoteReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendVideoNoteAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendVideoNoteReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
-instance ToJSON SendVideoNoteRequest where toJSON = gtoJSON
-
-instance ToMultipart Tmp SendVideoNoteRequest where
-  toMultipart SendVideoNoteRequest{..} =
-    maybe id (makeFile "thumb") sendVideoNoteThumb $
-    makeFile "video_note" sendVideoNoteVideoNote $
-    MultipartData fields [] where
-    fields =
-      [ Input "chat_id" $ case sendVideoNoteChatId of
-          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
-          SomeChatUsername txt -> txt
-      ] <> catMaybes
-      [ sendVideoNoteMessageThreadId <&>
-        \t -> Input "message_thread_id" (T.pack $ show t)
-      , sendVideoNoteDisableNotification <&>
-        \t -> Input "disable_notification" (bool "false" "true" t)
-      , sendVideoNoteProtectContent <&>
-        \t -> Input "protect_content" (bool "false" "true" t)
-      , sendVideoNoteReplyToMessageId <&>
-        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
-      , sendVideoNoteAllowSendingWithoutReply <&>
-        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
-      , sendVideoNoteReplyMarkup <&>
-        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
-      ]
-
-type SendVideoNoteContent
-  = "sendVideoNote"
-  :> MultipartForm Tmp SendVideoNoteRequest
-  :> Post '[JSON] (Response Message)
-
-type SendVideoNoteLink
-  = "sendVideoNote"
-  :> ReqBody '[JSON] SendVideoNoteRequest
-  :> Post '[JSON] (Response Message)
-
--- | As of v.4.0, Telegram clients support rounded
---   square mp4 videos of up to 1 minute long. Use
---   this method to send video messages.
---   On success, the sent Message is returned.
-sendVideoNote :: SendVideoNoteRequest ->  ClientM (Response Message)
-sendVideoNote r = case (sendVideoNoteVideoNote r, sendVideoNoteThumb r) of
-  (InputFile{}, _) -> do
-    boundary <- liftIO genBoundary
-    client (Proxy @SendVideoNoteContent) (boundary, r)
-  (_, Just InputFile{}) -> do
-    boundary <- liftIO genBoundary
-    client (Proxy @SendVideoNoteContent) (boundary, r)
-  _ ->  client (Proxy @SendVideoNoteLink) r
-
--- | Request parameters for 'sendMediaGroup'.
-data SendMediaGroupRequest = SendMediaGroupRequest
-  { sendMediaGroupChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendMediaGroupMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendMediaGroupMedia :: [InputMedia] -- ^ A JSON-serialized array describing messages to be sent, must include 2-10 items. InputMediaAudio, InputMediaDocument, InputMediaPhoto or InputMediaVideo.
-  , sendMediaGroupDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendMediaGroupProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
-  , sendMediaGroupReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendMediaGroupAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendMediaGroupReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
-instance ToJSON SendMediaGroupRequest where toJSON = gtoJSON
-
-type SendMediaGroup = "sendMediaGroup"
-  :> ReqBody '[JSON] SendMediaGroupRequest
-  :> Post '[JSON] (Response [Message])
-
--- | Use this method to send a group of photos, videos,
---   documents or audios as an album. Documents
---   and audio files can be only grouped in an album
---   with messages of the same type.
---   On success, an array of Messages that were sent is returned.
-sendMediaGroup :: SendMediaGroupRequest ->  ClientM (Response [Message])
-sendMediaGroup = client (Proxy @SendMediaGroup)
-
--- | Request parameters for 'sendLocation'.
-data SendLocationRequest = SendLocationRequest
-  { sendLocationChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendLocationMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendLocationLatitude :: Float -- ^ Latitude of new location
-  , sendLocationLongitude :: Float -- ^ Longitude of new location
-  , sendLocationHorizontalAccuracy :: Maybe Float -- ^ The radius of uncertainty for the location, measured in meters; 0-1500
-  , sendLocationLivePeriod :: Int -- ^ Period in seconds for which the location will be updated (see Live Locations, should be between 60 and 86400.)
-  , sendLocationHeading :: Maybe Int -- ^ Direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
-  , sendLocationProximityAlertRadius :: Maybe Int  -- ^ Maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
-  , sendLocationDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendLocationProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
-  , sendLocationReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendLocationAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendLocationReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
--- | Request parameters for 'editMessageLiveLocation'.
-data EditMessageLiveLocationRequest = EditMessageLiveLocationRequest
-  { editMessageLiveLocationChatId :: Maybe SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , editMessageLiveLocationMessageId :: Maybe MessageId -- ^ Required if inline_message_id is not specified. Identifier of the message with live location to stop
-  , editMessageLiveLocationInlineMessageId :: Maybe Text -- ^  	Required if chat_id and message_id are not specified. Identifier of the inline message
-  , editMessageLiveLocationLatitude :: Float -- ^ Latitude of new location
-  , editMessageLiveLocationLongitude :: Float -- ^ Longitude of new location
-  , editMessageLiveLocationHorizontalAccuracy :: Maybe Float -- ^ The radius of uncertainty for the location, measured in meters; 0-1500
-  , editMessageLiveLocationHeading :: Maybe Int -- ^ Direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
-  , editMessageLiveLocationProximityAlertRadius :: Maybe Int  -- ^ Maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
-  , editMessageLiveLocationReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
--- | Request parameters for 'stopMessageLiveLocation'.
-data StopMessageLiveLocationRequest = StopMessageLiveLocationRequest
-  { stopMessageLiveLocationChatId :: Maybe SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , stopMessageLiveLocationMessageId :: Maybe MessageId -- ^ Required if inline_message_id is not specified. Identifier of the message with live location to stop
-  , stopMessageLiveLocationInlineMessageId :: Maybe Text -- ^  	Required if chat_id and message_id are not specified. Identifier of the inline message
-  , stopMessageLiveLocationReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
--- | Request parameters for 'sendVenue'.
-data SendVenueRequest = SendVenueRequest
-  { sendVenueChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendVenueMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendVenueLatitude :: Float -- ^ Latitude of the venue
-  , sendVenueLongitude :: Float -- ^ Longitude of the venue
-  , sendVenueTitle :: Text -- ^ Name of the venue
-  , sendVenueAddress :: Text -- ^ Address of the venue
-  , sendVenueFoursquareId :: Maybe Text -- ^ Foursquare identifier of the venue
-  , sendVenueFoursquareType :: Maybe Text -- ^ Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
-  , sendVenueGooglePlaceId :: Maybe Text -- ^ Google Places identifier of the venue
-  , sendVenueGooglePlaceType :: Maybe Text -- ^ Google Places type of the venue. (See supported types <https:\/\/developers.google.com\/maps\/documentation\/places\/web-service\/supported_types>.)
-  , sendVenueDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendVenueProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
-  , sendVenueReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendVenueAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendVenueReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
--- | Request parameters for 'sendContact'.
-data SendContactRequest = SendContactRequest
-  { sendContactChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendContactMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendContactPhoneNumber :: Text -- ^ Contact's phone number
-  , sendContactFirstName  :: Text -- ^ Contact's first name
-  , sendContactLastName  :: Text -- ^ Contact's last name
-  , sendContactVcard  :: Text -- ^ Additional data about the contact in the form of a vCard, 0-2048 bytes
-  , sendContactDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendContactProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
-  , sendContactReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendContactAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendContactReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
--- | Request parameters for 'sendPoll'.
-data SendPollRequest = SendPollRequest
-  { sendPollChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendPollMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendPollQuestion :: Text -- ^ Poll question, 1-300 characters
-  , sendPollOptions :: [Text] -- ^ A JSON-serialized list of answer options, 2-10 strings 1-100 characters each
-  , sendPollIsAnonymous :: Maybe Bool -- ^ True, if the poll needs to be anonymous, defaults to True
-  , sendPollType :: Maybe Text -- ^ Poll type, “quiz” or “regular”, defaults to “regular”
-  , sendPollAllowsMultipleAnswers :: Maybe Bool -- ^ True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
-  , sendPollCorrectOptionId :: Maybe Int -- ^ 0-based identifier of the correct answer option, required for polls in quiz mode
-  , sendPollExplanation :: Maybe Text -- ^ Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line feeds after entities parsing
-  , sendPollExplanationParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-  , sendPollExplanationEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the poll explanation, which can be specified instead of parse_mode
-  , sendPollOpenPeriod :: Maybe Int -- ^ Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with close_date.
-  , sendPollCloseDate :: Maybe Int -- ^ Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 600 seconds in the future. Can't be used together with open_period.
-  , sendPollIsClosed :: Maybe Bool -- ^ Pass True, if the poll needs to be immediately closed. This can be useful for poll preview.
-  , sendPollDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendPollProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
-  , sendPollReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendPollAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendPollReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
--- | Request parameters for 'sendDice'.
-data SendDiceRequest = SendDiceRequest
-  { sendDiceChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendDiceMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendDiceEmoji :: Maybe Text -- ^ Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, “🏀”, “⚽”, “🎳”, or “🎰”. Dice can have values 1-6 for “🎲”, “🎯” and “🎳”, values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”. Defaults to “🎲”
-  , sendDiceDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendDiceProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding
-  , sendDiceReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
-  , sendDiceAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
-  , sendDiceReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-  }
-  deriving Generic
-
-type SendChatAction = "sendChatAction"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> QueryParam "message_thread_id" MessageThreadId
-  :> RequiredQueryParam "action" Text
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method when you need to tell the
---   user that something is happening on the bot's side.
---   The status is set for 5 seconds or less
---   (when a message arrives from your bot, Telegram
---   clients clear its typing status).
---   Returns True on success.
---
---   Example: The ImageBot needs some time to
---   process a request and upload the image.
---   Instead of sending a text message along
---   the lines of “Retrieving image, please wait…”,
---   the bot may use sendChatAction with action = upload_photo.
---   The user will see a “sending photo” status for the bot.
---
---   We only recommend using this method when a
---   response from the bot will take a noticeable
---   amount of time to arrive.
-sendChatAction :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
-  -> Maybe MessageThreadId -- ^ Unique identifier for the target message thread; supergroups only.
-  -> Text -- ^ Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes.
-  -> ClientM (Response  Bool)
-sendChatAction = client (Proxy @SendChatAction)
-
--- | Request parameters for 'getUserProfilePhotos'.
-data GetUserProfilePhotosRequest = GetUserProfilePhotosRequest
-  { getUserProfilePhotosUserId :: UserId -- ^ Unique identifier of the target user
-  , getUserProfilePhotosOffset :: Maybe Int -- ^ Sequential number of the first photo to be returned. By default, all photos are returned.
-  , getUserProfilePhotosLimit :: Maybe Int -- ^ Limits the number of photos to be retrieved. Values between 1-100 are accepted. Defaults to 100.
-  }
-  deriving Generic
-
--- | Request parameters for 'banChatMember'.
-data BanChatMemberRequest = BanChatMemberRequest
-  { banChatMemberChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , banChatMemberUserId :: UserId -- ^ Unique identifier of the target user
-  , banChatMemberUntilDate :: Maybe Int -- ^ Date when the user will be unbanned, unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever. Applied for supergroups and channels only.
-  , banChatMemberRevokeMessages :: Maybe Bool -- ^ Pass True to delete all messages from the chat for the user that is being removed. If False, the user will be able to see messages in the group that were sent before the user was removed. Always True for supergroups and channels.
-  }
-  deriving Generic
-
--- | Request parameters for 'unbanChatMember'.
-data UnbanChatMemberRequest = UnbanChatMemberRequest
-  { unbanChatMemberChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , unbanChatMemberUserId :: UserId -- ^ Unique identifier of the target user
-  , unbanChatMemberOnlyIfBanned :: Maybe Bool -- ^ Do nothing if the user is not banned
-  }
-  deriving Generic
-
--- | Request parameters for 'restrictChatMember'.
-data RestrictChatMemberRequest = RestrictChatMemberRequest
-  { restrictChatMemberChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , restrictChatMemberUserId :: UserId -- ^ Unique identifier of the target user.
-  , restrictChatMemberPermissions :: ChatPermissions -- ^ A JSON-serialized object for new user permissions.
-  , restrictChatMemberUseIndependentChatPermissions :: Maybe Bool -- ^ Pass 'True' if chat permissions are set independently. Otherwise, the @can_send_other_messages@ and @can_add_web_page_previews@ permissions will imply the @can_send_messages@, @can_send_audios@, @can_send_documents@, @can_send_photos@, @can_send_videos@, @can_send_video_notes@, and @can_send_voice_notes@ permissions; the @can_send_polls@ permission will imply the @can_send_messages@ permission.
-  , restrictChatMemberUntilDate :: Maybe Int -- ^ Date when restrictions will be lifted for the user, unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever.
-  }
-  deriving Generic
-
--- | Request parameters for 'promoteChatMember'.
-data PromoteChatMemberRequest = PromoteChatMemberRequest
-  { promoteChatMemberChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , promoteChatMemberUserId :: UserId -- ^ Unique identifier of the target user.
-  , promoteChatMemberIsAnonymous :: Maybe Bool -- ^ Pass 'True', if the administrator's presence in the chat is hidden.
-  , promoteChatMemberCanManageChat :: Maybe Bool -- ^ Pass 'True', if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege.
-  , promoteChatMemberCanPostMessages :: Maybe Bool -- ^ Pass 'True', if the administrator can create channel posts, channels only.
-  , promoteChatMemberCanEditMessages :: Maybe Bool -- ^ Pass 'True', if the administrator can edit messages of other users and can pin messages, channels only.
-  , promoteChatMemberCanDeleteMessages :: Maybe Bool -- ^ Pass 'True', if the administrator can delete messages of other users.
-  , promoteChatMemberCanManageVideoChats :: Maybe Bool -- ^ Pass 'True', if the administrator can manage video chats.
-  , promoteChatMemberCanRestrictMembers :: Maybe Bool -- ^ Pass 'True', if the administrator can restrict, ban or unban chat members.
-  , promoteChatMemberCanPromoteMembers :: Maybe Bool -- ^ Pass 'True', if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him).
-  , promoteChatMemberCanChangeInfo :: Maybe Bool -- ^ Pass 'True', if the administrator can change chat title, photo and other settings.
-  , promoteChatMemberCanInviteUsers :: Maybe Bool -- ^ Pass 'True', if the administrator can invite new users to the chat.
-  , promoteChatMemberCanPinMessages :: Maybe Bool -- ^ Pass 'True', if the administrator can pin messages, supergroups only.
-  , promoteChatMemberCanManageTopics :: Maybe Bool -- ^ Pass 'True', if the user is allowed to create, rename, close, and reopen forum topics, supergroups only.
-  }
-  deriving Generic
-
--- | Request parameters for 'setChatAdministratorCustomTitle'.
-data SetChatAdministratorCustomTitleRequest = SetChatAdministratorCustomTitleRequest
-  { setChatAdministratorCustomTitleChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , setChatAdministratorCustomTitleUserId :: UserId -- ^ Unique identifier of the target user
-  , setChatAdministratorCustomTitleCustomTitle :: Text -- ^ New custom title for the administrator; 0-16 characters, emoji are not allowed
-  }
-  deriving Generic
-
-type BanChatSenderChat = "banChatSenderChat"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> RequiredQueryParam "sender_chat_id" ChatId
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to ban a channel chat
---   in a supergroup or a channel. Until the
---   chat is unbanned, the owner of the banned
---   chat won't be able to send messages on
---   behalf of any of their channels. The bot
---   must be an administrator in the supergroup
---   or channel for this to work and must have
---   the appropriate administrator rights.
---   Returns True on success.
-banChatSenderChat :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ChatId -- ^ Unique identifier of the target sender chat
-  -> ClientM (Response  Bool)
-banChatSenderChat = client (Proxy @BanChatSenderChat)
-
-type UnbanChatSenderChat = "unbanChatSenderChat"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> RequiredQueryParam "sender_chat_id" ChatId
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to unban a previously
---   banned channel chat in a supergroup
---   or channel. The bot must be an administrator
---   for this to work and must have the appropriate
---   administrator rights.
---   Returns True on success.
-unbanChatSenderChat :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ChatId -- ^ Unique identifier of the target sender chat
-  -> ClientM (Response  Bool)
-unbanChatSenderChat = client (Proxy @UnbanChatSenderChat)
-
--- | Request parameters for 'setChatPermissions'.
-data SetChatPermissionsRequest = SetChatPermissionsRequest
-  { setChatPermissionsChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , setChatPermissionsPermissions :: ChatPermissions -- ^ A JSON-serialized object for new default chat permissions.
-  , setChatPermissionsUseIndependentChatPermissions :: Maybe Bool -- ^ Pass 'True' if chat permissions are set independently. Otherwise, the @can_send_other_messages@ and @can_add_web_page_previews@ permissions will imply the @can_send_messages@, @can_send_audios@, @can_send_documents@, @can_send_photos@, @can_send_videos@, @can_send_video_notes@, and @can_send_voice_notes@ permissions; the @can_send_polls@ permission will imply the @can_send_messages@ permission.
-  }
-  deriving Generic
-
-type ExportChatInviteLink = "exportChatInviteLink"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> Post '[JSON] (Response Text)
-
--- | Use this method to generate a new
---   primary invite link for a chat; any
---   previously generated primary link is
---   revoked. The bot must be an administrator
---   in the chat for this to work and must have
---   the appropriate administrator rights.
---   Returns the new invite link as String on success.
-exportChatInviteLink :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ClientM (Response  Text)
-exportChatInviteLink = client (Proxy @ExportChatInviteLink)
-
--- | Request parameters for 'createChatInviteLink'.
-data CreateChatInviteLinkRequest = CreateChatInviteLinkRequest
-  { createChatInviteLinkChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , createChatInviteLinkName :: Maybe Text -- ^ Invite link name; 0-32 characters
-  , createChatInviteLinkExpireDate :: Maybe Integer -- ^ Point in time (Unix timestamp) when the link will expire
-  , createChatInviteLinkMemberLimit :: Maybe Int -- ^ Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
-  , createChatInviteLinkCreatesJoinRequest :: Maybe Bool -- ^ True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
-  }
-  deriving Generic
-
--- | Request parameters for 'editChatInviteLink'.
-data EditChatInviteLinkRequest = EditChatInviteLinkRequest
-  { editChatInviteLinkChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , editChatInviteLinkInviteLink :: Text -- ^	The invite link to edit
-  , editChatInviteLinkName :: Maybe Text -- ^ Invite link name; 0-32 characters
-  , editChatInviteLinkExpireDate :: Maybe Integer -- ^ Point in time (Unix timestamp) when the link will expire
-  , editChatInviteLinkMemberLimit :: Maybe Int -- ^ Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
-  , editChatInviteLinkCreatesJoinRequest :: Maybe Bool -- ^ True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
-  }
-  deriving Generic
-
-type RevokeChatInviteLink = "revokeChatInviteLink"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> RequiredQueryParam "invite_link" Text
-  :> Post '[JSON] (Response ChatInviteLink)
-
--- | Use this method to revoke an invite
---   link created by the bot. If the primary 
---   link is revoked, a new link is automatically 
---   generated. The bot must be an administrator 
---   in the chat for this to work and must have 
---   the appropriate administrator rights. 
---   Returns the revoked invite link as ChatInviteLink object.
-revokeChatInviteLink :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> Text -- ^ The invite link to revoke
-  -> ClientM (Response  ChatInviteLink)
-revokeChatInviteLink = client (Proxy @RevokeChatInviteLink)
-
-type ApproveChatJoinRequest = "approveChatJoinRequest"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> RequiredQueryParam "user_id" UserId
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to approve a chat 
---   join request. The bot must be an 
---   administrator in the chat for this 
---   to work and must have the can_invite_users 
---   administrator right. 
---   Returns True on success.
-approveChatJoinRequest :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> UserId -- ^ Unique identifier of the target user
-  -> ClientM (Response Bool)
-approveChatJoinRequest = client (Proxy @ApproveChatJoinRequest)
-
-type DeclineChatJoinRequest = "declineChatJoinRequest"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> RequiredQueryParam "user_id" UserId
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to decline a chat 
---   join request. The bot must be an 
---   administrator in the chat for this 
---   to work and must have the can_invite_users 
---   administrator right. 
---   Returns True on success.
-declineChatJoinRequest :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> UserId -- ^ Unique identifier of the target user
-  -> ClientM (Response Bool)
-declineChatJoinRequest = client (Proxy @DeclineChatJoinRequest)
-
--- | Request parameters for 'setChatPhoto'.
-data SetChatPhotoRequest = SetChatPhotoRequest
-  { setChatPhotoChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , setChatPhotoPhoto :: InputFile -- ^ 	New chat photo, uploaded using multipart/form-data
-  }
-
-instance ToMultipart Tmp SetChatPhotoRequest where
-  toMultipart SetChatPhotoRequest{..} =
-    makeFile "photo" setChatPhotoPhoto (MultipartData fields []) where
-    fields =
-      [ Input "chat_id" $ case setChatPhotoChatId of
-          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
-          SomeChatUsername txt -> txt
-      ]
-
-type SetChatPhoto = "setChatPhoto"
-  :> MultipartForm Tmp SetChatPhotoRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to set a new profile 
---   photo for the chat. Photos can't be changed
---   for private chats. The bot must be an 
---   administrator in the chat for this to work 
---   and must have the appropriate administrator rights. 
---   Returns True on success.
---
--- *Note*: Only 'InputFile' case might be used in 'SetChatPhotoRequest'.
--- Rest cases will be rejected by Telegram.
-setChatPhoto :: SetChatPhotoRequest ->  ClientM (Response Bool)
-setChatPhoto r =do
-      boundary <- liftIO genBoundary
-      client (Proxy @SetChatPhoto) (boundary, r)
-
-type DeleteChatPhoto = "deleteChatPhoto"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to delete a chat photo.
---   Photos can't be changed for private chats.
---   The bot must be an administrator in the chat 
---   for this to work and must have the appropriate 
---   administrator rights. 
---   Returns True on success.
-deleteChatPhoto :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ClientM (Response Bool)
-deleteChatPhoto = client (Proxy @DeleteChatPhoto)
-
-type SetChatTitle = "setChatTitle"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> RequiredQueryParam "title" Text
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to change the title of
---   a chat. Titles can't be changed for private
---   chats. The bot must be an administrator in 
---   the chat for this to work and must have the 
---   appropriate administrator rights. 
---   Returns True on success.
-setChatTitle :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> Text -- ^ New chat title, 0-255 characters
-  -> ClientM (Response Bool)
-setChatTitle = client (Proxy @SetChatTitle)
-
-type SetChatDescription = "setChatDescription"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> QueryParam "description" Text
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to change the description 
---   of a group, a supergroup or a channel. The 
---   bot must be an administrator in the chat 
---   for this to work and must have the appropriate 
---   administrator rights. 
---   Returns True on success.
-setChatDescription :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> Maybe Text -- ^ New chat description, 0-255 characters
-  -> ClientM (Response Bool)
-setChatDescription = client (Proxy @SetChatDescription)
-
--- | Request parameters for 'pinChatMessage'.
-data PinChatMessageRequest = PinChatMessageRequest
-  { pinChatMessageChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-  , pinChatMessageMessageId :: MessageId -- ^ Identifier of a message to pin
-  , pinChatMessageDisableNotification :: Maybe Bool -- ^ Pass True, if it is not necessary to send a notification to all chat members about the new pinned message. Notifications are always disabled in channels and private chats.
-  }
-  deriving Generic
-
-type UnpinChatMessage = "unpinChatMessage"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> QueryParam "message_id" MessageId
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to remove a message from the
---   list of pinned messages in a chat. If the chat 
---   is not a private chat, the bot must be an administrator
---   in the chat for this to work and must have the 
---   'can_pin_messages' administrator right in a supergroup 
---   or 'can_edit_messages' administrator right in a 
---   channel. 
---   Returns True on success.
-unpinChatMessage :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> Maybe MessageId -- ^ Identifier of a message to unpin. If not specified, the most recent pinned message (by sending date) will be unpinned.
-  -> ClientM (Response Bool)
-unpinChatMessage = client (Proxy @UnpinChatMessage)
-
-type UnpinAllChatMessages = "unpinAllChatMessages"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to clear the list of pinned 
---   messages in a chat. If the chat is not a private 
---   chat, the bot must be an administrator in the 
---   chat for this to work and must have the 'can_pin_messages' 
---   administrator right in a supergroup or 'can_edit_messages' 
---   administrator right in a channel. 
---   Returns True on success.
-unpinAllChatMessages :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ClientM (Response Bool)
-unpinAllChatMessages = client (Proxy @UnpinAllChatMessages)
-
-type LeaveChat = "leaveChat"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method for your bot to leave a group, supergroup or channel. 
---   Returns True on success.
-leaveChat :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ClientM (Response Bool)
-leaveChat = client (Proxy @LeaveChat)
-
-type GetChat = "getChat"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> Post '[JSON] (Response Chat)
-
--- | Use this method to get up to date information 
---   about the chat (current name of the user for 
---   one-on-one conversations, current username of 
---   a user, group or channel, etc.). 
---   Returns a Chat object on success.
-getChat :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ClientM (Response Chat)
-getChat = client (Proxy @GetChat)
-
-type GetChatAdministrators = "getChatAdministrators"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> Post '[JSON] (Response [ChatMember])
-
--- | Use this method to get a list of administrators
---   in a chat. On success, returns an Array of 
---   ChatMember objects that contains information 
---   about all chat administrators except other bots. 
---   If the chat is a group or a supergroup and no 
---   administrators were appointed, only the creator 
---   will be returned.
-getChatAdministrators :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ClientM (Response [ChatMember])
-getChatAdministrators = client (Proxy @GetChatAdministrators)
-
-type GetChatMemberCount = "getChatMemberCount"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> Post '[JSON] (Response Integer)
-
--- | Use this method to get the number of members in a chat. 
---   Returns Int on success.
-getChatMemberCount :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ClientM (Response Integer)
-getChatMemberCount = client (Proxy @GetChatMemberCount)
-
-type GetChatMember = "getChatMember"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> RequiredQueryParam "user_id" UserId
-  :> Post '[JSON] (Response ChatMember)
-
--- | Use this method to get information about a member of a chat. 
---   Returns a ChatMember object on success.
-getChatMember :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> UserId -- ^ 	Unique identifier of the target user
-  -> ClientM (Response ChatMember)
-getChatMember = client (Proxy @GetChatMember)
-
-type SetChatStickerSet = "setChatStickerSet"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> RequiredQueryParam "sticker_set_name" Text
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to set a new group sticker
---   set for a supergroup. The bot must be an 
---   administrator in the chat for this to work 
---   and must have the appropriate administrator 
---   rights. Use the field can_set_sticker_set 
---   optionally returned in getChat requests to 
---   check if the bot can use this method. 
---   Returns True on success.
-setChatStickerSet :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> Text -- ^ 	Name of the sticker set to be set as the group sticker set
-  -> ClientM (Response Bool)
-setChatStickerSet = client (Proxy @SetChatStickerSet)
-
-type DeleteChatStickerSet = "deleteChatStickerSet"
-  :> RequiredQueryParam "chat_id" SomeChatId
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to delete a group sticker 
---   set from a supergroup. The bot must be an 
---   administrator in the chat for this to work 
---   and must have the appropriate administrator 
---   rights. Use the field can_set_sticker_set 
---   optionally returned in getChat requests 
---   to check if the bot can use this method. 
---   Returns True on success.
-deleteChatStickerSet :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-  -> ClientM (Response Bool)
-deleteChatStickerSet = client (Proxy @DeleteChatStickerSet)
-
--- | Request parameters for 'answerCallbackQuery'.
-data AnswerCallbackQueryRequest = AnswerCallbackQueryRequest
-  { answerCallbackQueryCallbackQueryId :: CallbackQueryId -- ^ Unique identifier for the query to be answered
-  , answerCallbackQueryText :: Maybe Text -- ^ Text of the notification. If not specified, nothing will be shown to the user, 0-200 characters
-  , answerCallbackQueryShowAlert :: Maybe Bool -- ^ If True, an alert will be shown by the client instead of a notification at the top of the chat screen. Defaults to false.
-  , answerCallbackQueryUrl :: Maybe Text
-    -- ^ URL that will be opened by the user's client. If you have created a Game and accepted the conditions via @Botfather, specify the URL that opens your game — note that this will only work if the query comes from a callback_game button.
-    --
-    --   Otherwise, you may use links like t.me/your_bot?start=XXXX that open your bot with a parameter.
-  , answerCallbackQueryCacheTime :: Maybe Integer -- ^ The maximum amount of time in seconds that the result of the callback query may be cached client-side. Telegram apps will support caching starting in version 3.14. Defaults to 0.
-  }
-  deriving Generic
-
--- | Request parameters for 'setMyCommands'.
-data SetMyCommandsRequest = SetMyCommandsRequest
-  { setMyCommandsCommands :: [BotCommand] -- ^ A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
-  , setMyCommandsScope :: Maybe BotCommandScope -- ^ A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
-  , setMyCommandsLanguageCode :: Maybe Text -- ^ A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
-  }
-  deriving Generic
-
--- | Request parameters for 'deleteMyCommands'.
-data DeleteMyCommandsRequest = DeleteMyCommandsRequest
-  { deleteMyCommandsScope :: Maybe BotCommandScope  -- ^ A JSON-serialized object, describing scope of users. Defaults to BotCommandScopeDefault. 
-  , deleteMyCommandsLanguageCode :: Maybe Text  -- ^ 	A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
-  }
-  deriving Generic
-
--- | Request parameters for 'getMyCommands'.
-data GetMyCommandsRequest = GetMyCommandsRequest
-  { getMyCommandsScope :: Maybe BotCommandScope  -- ^ A JSON-serialized object, describing scope of users. Defaults to BotCommandScopeDefault. 
-  , getMyCommandsLanguageCode :: Maybe Text   -- ^ 	A two-letter ISO 639-1 language code or an empty string
-  }
-  deriving Generic
-
--- | Request parameters for 'setChatMenuButton'
-
-data SetChatMenuButtonRequest = SetChatMenuButtonRequest
-  { setChatMenuButtonRequestChatId     :: Maybe ChatId     -- ^ Unique identifier for the target private chat. If not specified, default bot's menu button will be changed.
-  , setChatMenuButtonRequestMenuButton :: Maybe MenuButton -- ^ A JSON-serialized object for the new bot's menu button. Defaults to @MenuButtonDefault@.
-  }
-  deriving Generic
-
--- | Request parameters for 'getChatMenuButton'
-
-data GetChatMenuButtonRequest = GetChatMenuButtonRequest
-  { getChatMenuButtonRequestChatId     :: Maybe ChatId     -- ^ Unique identifier for the target private chat. If not specified, default bot's menu button will be returned.
-  }
-  deriving Generic
-
--- | Request parameters for 'setMyDefaultAdministratorRights'
-data SetMyDefaultAdministratorRightsRequest = SetMyDefaultAdministratorRightsRequest
-  { setMyDefaultAdministratorRightsRequestRights      :: Maybe ChatAdministratorRights -- ^ A JSON-serialized object describing new default administrator rights. If not specified, the default administrator rights will be cleared.
-  , setMyDefaultAdministratorRightsRequestForChannels :: Maybe Bool -- ^ Pass 'True' to change the default administrator rights of the bot in channels. Otherwise, the default administrator rights of the bot for groups and supergroups will be changed.
-  }
-  deriving Generic
-
--- | Request parameters for 'getMyDefaultAdministratorRights'
-data GetMyDefaultAdministratorRightsRequest = GetMyDefaultAdministratorRightsRequest
-  { getMyDefaultAdministratorRightsRequestForChannels :: Maybe Bool -- ^ Pass 'True' to get default administrator rights of the bot in channels. Otherwise, default administrator rights of the bot for groups and supergroups will be returned.
-  }
-  deriving Generic
-
-foldMap deriveJSON'
-  [ ''SetMyDefaultAdministratorRightsRequest
-  , ''GetMyDefaultAdministratorRightsRequest
-  , ''GetChatMenuButtonRequest
-  , ''SetChatMenuButtonRequest
-  , ''GetMyCommandsRequest
-  , ''DeleteMyCommandsRequest
-  , ''SetMyCommandsRequest
-  , ''AnswerCallbackQueryRequest
-  , ''EditChatInviteLinkRequest
-  , ''PinChatMessageRequest
-  , ''CreateChatInviteLinkRequest
-  , ''SetChatPermissionsRequest
-  , ''SetChatAdministratorCustomTitleRequest
-  , ''PromoteChatMemberRequest
-  , ''RestrictChatMemberRequest
-  , ''UnbanChatMemberRequest
-  , ''BanChatMemberRequest
-  , ''GetUserProfilePhotosRequest
-  , ''SendDiceRequest
-  , ''SendPollRequest
-  , ''SendContactRequest
-  , ''SendVenueRequest
-  , ''StopMessageLiveLocationRequest
-  , ''EditMessageLiveLocationRequest
-  , ''SendLocationRequest
-  , ''CopyMessageRequest
-  ]
-
-type CopyMessage
-  = "copyMessage"
-  :> ReqBody '[JSON] CopyMessageRequest
-  :> Post '[JSON] (Response CopyMessageId)
-
--- | Use this method to copy messages of any kind.
---   Service messages and invoice messages can't be
---   copied. The method is analogous to the method
---   forwardMessage, but the copied message doesn't
---   have a link to the original message.
---   Returns the MessageId of the sent message on success.
-copyMessage :: CopyMessageRequest ->  ClientM (Response CopyMessageId)
-copyMessage = client (Proxy @CopyMessage)
-
-type SendLocation = "sendLocation"
-  :> ReqBody '[JSON] SendLocationRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send point on the map.
---   On success, the sent Message is returned.
-sendLocation :: SendLocationRequest ->  ClientM (Response Message)
-sendLocation = client (Proxy @SendLocation)
-
-type EditMessageLiveLocation = "editMessageLiveLocation"
-  :> ReqBody '[JSON] EditMessageLiveLocationRequest
-  :> Post '[JSON] (Response (Either Bool Message))
-
--- | Use this method to edit live location messages.
---   A location can be edited until its live_period
---   expires or editing is explicitly disabled by a
---   call to stopMessageLiveLocation. On success, if
---   the edited message is not an inline message, the
---   edited Message is returned, otherwise True is returned.
-editMessageLiveLocation :: EditMessageLiveLocationRequest ->  ClientM (Response (Either Bool Message))
-editMessageLiveLocation = client (Proxy @EditMessageLiveLocation)
-
-type StopMessageLiveLocation = "stopMessageLiveLocation"
-  :> ReqBody '[JSON] StopMessageLiveLocationRequest
-  :> Post '[JSON] (Response (Either Bool Message))
-
--- | Use this method to stop updating a live
---   location message before live_period
---   expires. On success, if the message is
---   not an inline message, the edited Message
---   is returned, otherwise True is returned.
-stopMessageLiveLocation :: StopMessageLiveLocationRequest ->  ClientM (Response (Either Bool Message))
-stopMessageLiveLocation = client (Proxy @StopMessageLiveLocation)
-
-type SendVenue = "sendVenue"
-  :> ReqBody '[JSON] SendVenueRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send information about a venue.
---   On success, the sent Message is returned.
-sendVenue :: SendVenueRequest ->  ClientM (Response Message)
-sendVenue = client (Proxy @SendVenue)
-
-type SendContact = "sendContact"
-  :> ReqBody '[JSON] SendContactRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send phone contacts.
---   On success, the sent Message is returned.
-sendContact :: SendContactRequest ->  ClientM (Response Message)
-sendContact = client (Proxy @SendContact)
-
-type SendPoll = "sendPoll"
-  :> ReqBody '[JSON] SendPollRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send a native poll.
---   On success, the sent Message is returned.
-sendPoll :: SendPollRequest ->  ClientM (Response Message)
-sendPoll = client (Proxy @SendPoll)
-
-type SendDice = "sendDice"
-  :> ReqBody '[JSON] SendDiceRequest
-  :> Post '[JSON] (Response Message)
-
--- | Use this method to send an animated emoji that
---   will display a random value.
---   On success, the sent Message is returned.
-sendDice :: SendDiceRequest ->  ClientM (Response Message)
-sendDice = client (Proxy @SendDice)
-
-type GetUserProfilePhotos = "getUserProfilePhotos"
-  :> ReqBody '[JSON] GetUserProfilePhotosRequest
-  :> Post '[JSON] (Response UserProfilePhotos)
-
--- | Use this method to get a list of profile pictures for a user.
---   Returns a UserProfilePhotos object.
-getUserProfilePhotos :: GetUserProfilePhotosRequest ->  ClientM (Response UserProfilePhotos)
-getUserProfilePhotos = client (Proxy @GetUserProfilePhotos)
-
-type BanChatMember = "banChatMember"
-  :> ReqBody '[JSON] BanChatMemberRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to ban a user in a
---   group, a supergroup or a channel.
---   In the case of supergroups and channels,
---   the user will not be able to return to
---   the chat on their own using invite links,
---   etc., unless unbanned first. The bot must
---   be an administrator in the chat for this
---   to work and must have the appropriate
---   administrator rights.
---   Returns True on success.
-banChatMember :: BanChatMemberRequest ->  ClientM (Response Bool)
-banChatMember = client (Proxy @BanChatMember)
-
-type UnbanChatMember = "unbanChatMember"
-  :> ReqBody '[JSON] UnbanChatMemberRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to unban a previously
---   banned user in a supergroup or channel.
---   The user will not return to the group
---   or channel automatically, but will be
---   able to join via link, etc. The bot must
---   be an administrator for this to work. By
---   default, this method guarantees that after
---   the call the user is not a member of the chat,
---   but will be able to join it. So if the user is
---   a member of the chat they will also be removed
---   from the chat. If you don't want this, use the
---   parameter only_if_banned.
---   Returns True on success.
-unbanChatMember :: UnbanChatMemberRequest ->  ClientM (Response Bool)
-unbanChatMember = client (Proxy @UnbanChatMember)
-
-type RestrictChatMember = "restrictChatMember"
-  :> ReqBody '[JSON] RestrictChatMemberRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to restrict a user
---   in a supergroup. The bot must be an
---   administrator in the supergroup for
---   this to work and must have the appropriate
---   administrator rights. Pass True for all
---   permissions to lift restrictions from a
---   user.
---   Returns True on success.
-restrictChatMember :: RestrictChatMemberRequest ->  ClientM (Response Bool)
-restrictChatMember = client (Proxy @RestrictChatMember)
-
-type PromoteChatMember = "promoteChatMember"
-  :> ReqBody '[JSON] PromoteChatMemberRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to promote or demote
---   a user in a supergroup or a channel.
---   The bot must be an administrator in
---   the chat for this to work and must have
---   the appropriate administrator rights.
---   Pass False for all boolean parameters
---   to demote a user.
---   Returns True on success.
-promoteChatMember ::PromoteChatMemberRequest ->  ClientM (Response Bool)
-promoteChatMember = client (Proxy @PromoteChatMember)
-
-type SetChatAdministratorCustomTitle = "setChatAdministratorCustomTitle"
-  :> ReqBody '[JSON] SetChatAdministratorCustomTitleRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to set a custom title
---   for an administrator in a supergroup
---   promoted by the bot.
---   Returns True on success.
-setChatAdministratorCustomTitle :: SetChatAdministratorCustomTitleRequest ->  ClientM (Response Bool)
-setChatAdministratorCustomTitle = client (Proxy @SetChatAdministratorCustomTitle)
-
-type SetChatPermissions = "setChatPermissions"
-  :> ReqBody '[JSON] SetChatPermissionsRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to set default chat
---   permissions for all members. The bot
---   must be an administrator in the group
---   or a supergroup for this to work and must
---   have the can_restrict_members administrator rights.
---   Returns True on success.
-setChatPermissions :: SetChatPermissionsRequest ->  ClientM (Response Bool)
-setChatPermissions = client (Proxy @SetChatPermissions)
-
-type CreateChatInviteLink = "createChatInviteLink"
-  :> ReqBody '[JSON] CreateChatInviteLinkRequest
-  :> Post '[JSON] (Response ChatInviteLink)
-
--- | Use this method to create an additional
---   invite link for a chat. The bot must be 
---   an administrator in the chat for this to 
---   work and must have the appropriate administrator 
---   rights. The link can be revoked using the 
---   method revokeChatInviteLink. 
---   Returns the new invite link as ChatInviteLink object.
-createChatInviteLink :: CreateChatInviteLinkRequest ->  ClientM (Response ChatInviteLink)
-createChatInviteLink = client (Proxy @CreateChatInviteLink)
-
-type EditChatInviteLink = "editChatInviteLink"
-  :> ReqBody '[JSON] EditChatInviteLinkRequest
-  :> Post '[JSON] (Response ChatInviteLink)
-
--- | Use this method to edit a non-primary
---   invite link created by the bot. The 
---   bot must be an administrator in the 
---   chat for this to work and must have 
---   the appropriate administrator rights.
---   Returns the edited invite link as a ChatInviteLink object.
-editChatInviteLink :: EditChatInviteLinkRequest ->  ClientM (Response ChatInviteLink)
-editChatInviteLink = client (Proxy @EditChatInviteLink)
-
-type PinChatMessage = "pinChatMessage"
-  :> ReqBody '[JSON] PinChatMessageRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to add a message to the list 
---   of pinned messages in a chat. If the chat is 
---   not a private chat, the bot must be an administrator 
---   in the chat for this to work and must have the 
---   'can_pin_messages' administrator right in a supergroup
---   or 'can_edit_messages' administrator right in a channel. 
---   Returns True on success.
-pinChatMessage :: PinChatMessageRequest ->  ClientM (Response Bool)
-pinChatMessage = client (Proxy @PinChatMessage)
-
-type AnswerCallbackQuery = "answerCallbackQuery"
-  :> ReqBody '[JSON] AnswerCallbackQueryRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to send answers to callback 
---   queries sent from inline keyboards. The answer 
---   will be displayed to the user as a notification 
---   at the top of the chat screen or as an alert. 
---   On success, True is returned.
---
---  Alternatively, the user can be redirected to 
---  the specified Game URL. For this option to work, 
---  you must first create a game for your bot via 
---  @Botfather and accept the terms. Otherwise, you 
---  may use links like t.me/your_bot?start=XXXX that 
---  open your bot with a parameter.
-answerCallbackQuery :: AnswerCallbackQueryRequest ->  ClientM (Response Bool)
-answerCallbackQuery = client (Proxy @AnswerCallbackQuery)
-
-type SetMyCommands = "setMyCommands"
-  :> ReqBody '[JSON] SetMyCommandsRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to change the list of 
---   the bot's commands. See <https:\/\/core.telegram.org\/bots#commands> 
---   for more details about bot commands. 
---   Returns True on success.
-setMyCommands :: SetMyCommandsRequest ->  ClientM (Response Bool)
-setMyCommands = client (Proxy @SetMyCommands)
-
-type DeleteMyCommands = "deleteMyCommands"
-  :> ReqBody '[JSON] DeleteMyCommandsRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to delete the list of 
---   the bot's commands for the given scope 
---   and user language. After deletion, higher 
---   level commands will be shown to affected users. 
---   Returns True on success.
-deleteMyCommands :: DeleteMyCommandsRequest -> ClientM (Response Bool)
-deleteMyCommands = client (Proxy @DeleteMyCommands)
-
-type GetMyCommands = "getMyCommands"
-  :> ReqBody '[JSON] GetMyCommandsRequest
-  :> Post '[JSON] (Response [BotCommand])
-
--- | Use this method to get the current list
---   of the bot's commands for the given scope 
---   and user language. Returns Array of BotCommand 
---   on success. If commands aren't set, an empty list 
---   is returned.
-getMyCommands :: GetMyCommandsRequest -> ClientM (Response [BotCommand])
-getMyCommands = client (Proxy @GetMyCommands)
-
-type SetChatMenuButton = "setChatMenuButton"
-  :> ReqBody '[JSON] SetChatMenuButtonRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to change the bot's menu button in a private chat,
---  or the default menu button. Returns True on success.
-setChatMenuButton :: SetChatMenuButtonRequest -> ClientM (Response Bool)
-setChatMenuButton = client (Proxy @SetChatMenuButton)
-
-type GetChatMenuButton = "getChatMenuButton"
-  :> ReqBody '[JSON] GetChatMenuButtonRequest
-  :> Post '[JSON] (Response MenuButton)
-
--- | Use this method to get the current value
---  of the bot's menu button in a private chat, or the default menu button.
--- Returns @MenuButton@ on success.
-getChatMenuButton :: GetChatMenuButtonRequest -> ClientM (Response MenuButton)
-getChatMenuButton = client (Proxy @GetChatMenuButton)
-
-type SetMyDefaultAdministratorRights = "setMyDefaultAdministratorRights"
-  :> ReqBody '[JSON] SetMyDefaultAdministratorRightsRequest
-  :> Post '[JSON] (Response Bool)
-
--- | Use this method to change the default administrator rights requested by the bot when it's added as an administrator to groups or channels. These rights will be suggested to users, but they are are free to modify the list before adding the bot. Returns 'True' on success.
-setMyDefaultAdministratorRights
-  :: SetMyDefaultAdministratorRightsRequest -> ClientM (Response Bool)
-setMyDefaultAdministratorRights = client (Proxy @SetMyDefaultAdministratorRights)
-
-type GetMyDefaultAdministratorRights = "getMyDefaultAdministratorRights"
-  :> ReqBody '[JSON] GetMyDefaultAdministratorRightsRequest
-  :> Post '[JSON] (Response ChatAdministratorRights)
-
--- | Use this method to get the current default administrator rights of the bot.
--- Returns 'ChatAdministratorRights' on success.
-getMyDefaultAdministratorRights
-  :: GetMyDefaultAdministratorRightsRequest -> ClientM (Response ChatAdministratorRights)
-getMyDefaultAdministratorRights = client (Proxy @GetMyDefaultAdministratorRights)
+module Telegram.Bot.API.Methods
+  ( AnswerCallbackQuery
+  , ApproveChatJoinRequest
+  , BanChatMember
+  , BanChatSenderChat
+  , CopyMessage
+  , CreateChatInviteLink
+  , DeclineChatJoinRequest
+  , DeleteChatPhoto
+  , DeleteChatStickerSet
+  , DeleteMessage
+  , DeleteMyCommands
+  , EditChatInviteLink
+  , EditMessageLiveLocation
+  , ExportChatInviteLink
+  , ForwardMessage
+  , GetChat
+  , GetChatAdministrators
+  , GetChatMember
+  , GetChatMemberCount
+  , GetChatMenuButton
+  , GetFile
+  , GetMe
+  , GetMyCommands
+  , GetMyDefaultAdministratorRights
+  , GetUserProfilePhotos
+  , LeaveChat
+  , PinChatMessage
+  , PromoteChatMember
+  , RestrictChatMember
+  , RevokeChatInviteLink
+  , SendAnimationContent
+  , SendAnimationLink
+  , SendAudioContent
+  , SendAudioLink
+  , SendChatAction
+  , SendContact
+  , SendDice
+  , SendDocumentContent
+  , SendDocumentLink
+  , SendLocation
+  , SendMediaGroup
+  , SendMessage
+  , SendPhotoContent
+  , SendPhotoLink
+  , SendPoll
+  , SendVenue
+  , SendVideoContent
+  , SendVideoLink
+  , SendVideoNoteContent
+  , SendVideoNoteLink
+  , SendVoiceContent
+  , SendVoiceLink
+  , SetChatAdministratorCustomTitle
+  , SetChatDescription
+  , SetChatMenuButton
+  , SetChatPermissions
+  , SetChatPhoto
+  , SetChatStickerSet
+  , SetChatTitle
+  , SetMyCommands
+  , SetMyDefaultAdministratorRights
+  , StopMessageLiveLocation
+  , UnbanChatMember
+  , UnbanChatSenderChat
+  , UnpinAllChatMessages
+  , UnpinChatMessage
+
+  , ParseMode (..)
+  , SomeReplyMarkup (..)
+
+  , AnswerCallbackQueryRequest (..)
+  , BanChatMemberRequest (..)
+  , CopyMessageRequest (..)
+  , CreateChatInviteLinkRequest (..)
+  , DeleteMyCommandsRequest (..)
+  , EditChatInviteLinkRequest (..)
+  , EditMessageLiveLocationRequest (..)
+  , ForwardMessageRequest (..)
+  , GetChatMenuButtonRequest (..)
+  , GetMyCommandsRequest (..)
+  , GetMyDefaultAdministratorRightsRequest (..)
+  , GetUserProfilePhotosRequest (..)
+  , PinChatMessageRequest (..)
+  , PromoteChatMemberRequest (..)
+  , RestrictChatMemberRequest (..)
+  , SendAnimationRequest (..)
+  , SendAudioRequest (..)
+  , SendContactRequest (..)
+  , SendDiceRequest (..)
+  , SendDocumentRequest (..)
+  , SendLocationRequest (..)
+  , SendMediaGroupRequest (..)
+  , SendMessageRequest (..)
+  , SendPhotoRequest (..)
+  , SendPollRequest (..)
+  , SendVenueRequest (..)
+  , SendVideoRequest (..)
+  , SendVideoNoteRequest (..)
+  , SendVoiceRequest (..)
+  , SetChatAdministratorCustomTitleRequest (..)
+  , SetChatMenuButtonRequest (..)
+  , SetChatPermissionsRequest (..)
+  , SetChatPhotoRequest (..)
+  , SetMyCommandsRequest (..)
+  , SetMyDefaultAdministratorRightsRequest (..)
+  , StopMessageLiveLocationRequest (..)
+  , UnbanChatMemberRequest (..)
+
+  , answerCallbackQuery
+  , approveChatJoinRequest
+  , banChatMember
+  , banChatSenderChat
+  , copyMessage
+  , createChatInviteLink
+  , declineChatJoinRequest
+  , deleteChatPhoto
+  , deleteChatStickerSet
+  , deleteMessage
+  , deleteMyCommands
+  , editChatInviteLink
+  , editMessageLiveLocation
+  , exportChatInviteLink
+  , forwardMessage
+  , getChat
+  , getChatAdministrators
+  , getChatMember
+  , getChatMemberCount
+  , getChatMenuButton
+  , getFile
+  , getMe
+  , getMyCommands
+  , getMyDefaultAdministratorRights
+  , getUserProfilePhotos
+  , leaveChat
+  , pinChatMessage
+  , promoteChatMember
+  , restrictChatMember
+  , revokeChatInviteLink
+  , sendAnimation
+  , sendAudio
+  , sendChatAction
+  , sendContact
+  , sendDice
+  , sendDocument
+  , sendLocation
+  , sendMediaGroup
+  , sendMessage
+  , sendPhoto
+  , sendPoll
+  , sendVenue
+  , sendVideo
+  , sendVideoNote
+  , sendVoice
+  , setChatAdministratorCustomTitle
+  , setChatDescription
+  , setChatMenuButton
+  , setChatPermissions
+  , setChatPhoto
+  , setChatStickerSet
+  , setChatTitle
+  , setMyCommands
+  , setMyDefaultAdministratorRights
+  , stopMessageLiveLocation
+  , unbanChatMember
+  , unbanChatSenderChat
+  , unpinAllChatMessages
+  , unpinChatMessage
+  ) where
+
+import Telegram.Bot.API.Types.ParseMode
+import Telegram.Bot.API.Types.SomeReplyMarkup
+
+import Telegram.Bot.API.Methods.AnswerCallbackQuery
+import Telegram.Bot.API.Methods.ApproveChatJoinRequest
+import Telegram.Bot.API.Methods.BanChatMember
+import Telegram.Bot.API.Methods.BanChatSenderChat
+import Telegram.Bot.API.Methods.CopyMessage
+import Telegram.Bot.API.Methods.CreateChatInviteLink
+import Telegram.Bot.API.Methods.DeclineChatJoinRequest
+import Telegram.Bot.API.Methods.DeleteChatPhoto
+import Telegram.Bot.API.Methods.DeleteChatStickerSet
+import Telegram.Bot.API.Methods.DeleteMessage
+import Telegram.Bot.API.Methods.DeleteMyCommands
+import Telegram.Bot.API.Methods.EditChatInviteLink
+import Telegram.Bot.API.Methods.EditMessageLiveLocation
+import Telegram.Bot.API.Methods.ExportChatInviteLink
+import Telegram.Bot.API.Methods.ForwardMessage
+import Telegram.Bot.API.Methods.GetChat
+import Telegram.Bot.API.Methods.GetChatAdministrators
+import Telegram.Bot.API.Methods.GetChatMember
+import Telegram.Bot.API.Methods.GetChatMemberCount
+import Telegram.Bot.API.Methods.GetChatMenuButton
+import Telegram.Bot.API.Methods.GetFile
+import Telegram.Bot.API.Methods.GetMe
+import Telegram.Bot.API.Methods.GetMyCommands
+import Telegram.Bot.API.Methods.GetMyDefaultAdministratorRights
+import Telegram.Bot.API.Methods.GetUserProfilePhotos
+import Telegram.Bot.API.Methods.LeaveChat
+import Telegram.Bot.API.Methods.PinChatMessage
+import Telegram.Bot.API.Methods.PromoteChatMember
+import Telegram.Bot.API.Methods.RestrictChatMember
+import Telegram.Bot.API.Methods.RevokeChatInviteLink
+import Telegram.Bot.API.Methods.SendAnimation
+import Telegram.Bot.API.Methods.SendAudio
+import Telegram.Bot.API.Methods.SendChatAction
+import Telegram.Bot.API.Methods.SendContact
+import Telegram.Bot.API.Methods.SendDice
+import Telegram.Bot.API.Methods.SendDocument
+import Telegram.Bot.API.Methods.SendLocation
+import Telegram.Bot.API.Methods.SendMediaGroup
+import Telegram.Bot.API.Methods.SendMessage
+import Telegram.Bot.API.Methods.SendPhoto
+import Telegram.Bot.API.Methods.SendPoll
+import Telegram.Bot.API.Methods.SendVenue
+import Telegram.Bot.API.Methods.SendVideo
+import Telegram.Bot.API.Methods.SendVideoNote
+import Telegram.Bot.API.Methods.SendVoice
+import Telegram.Bot.API.Methods.SetChatAdministratorCustomTitle
+import Telegram.Bot.API.Methods.SetChatDescription
+import Telegram.Bot.API.Methods.SetChatMenuButton
+import Telegram.Bot.API.Methods.SetChatPermissions
+import Telegram.Bot.API.Methods.SetChatPhoto
+import Telegram.Bot.API.Methods.SetChatStickerSet
+import Telegram.Bot.API.Methods.SetChatTitle
+import Telegram.Bot.API.Methods.SetMyCommands
+import Telegram.Bot.API.Methods.SetMyDefaultAdministratorRights
+import Telegram.Bot.API.Methods.StopMessageLiveLocation
+import Telegram.Bot.API.Methods.UnbanChatMember
+import Telegram.Bot.API.Methods.UnbanChatSenderChat
+import Telegram.Bot.API.Methods.UnpinAllChatMessages
+import Telegram.Bot.API.Methods.UnpinChatMessage

--- a/src/Telegram/Bot/API/Methods/AnswerCallbackQuery.hs
+++ b/src/Telegram/Bot/API/Methods/AnswerCallbackQuery.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.AnswerCallbackQuery where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'answerCallbackQuery'
+
+-- | Request parameters for 'answerCallbackQuery'.
+data AnswerCallbackQueryRequest = AnswerCallbackQueryRequest
+  { answerCallbackQueryCallbackQueryId :: CallbackQueryId -- ^ Unique identifier for the query to be answered
+  , answerCallbackQueryText :: Maybe Text -- ^ Text of the notification. If not specified, nothing will be shown to the user, 0-200 characters
+  , answerCallbackQueryShowAlert :: Maybe Bool -- ^ If True, an alert will be shown by the client instead of a notification at the top of the chat screen. Defaults to false.
+  , answerCallbackQueryUrl :: Maybe Text
+    -- ^ URL that will be opened by the user's client. If you have created a Game and accepted the conditions via @Botfather, specify the URL that opens your game — note that this will only work if the query comes from a callback_game button.
+    --
+    --   Otherwise, you may use links like t.me/your_bot?start=XXXX that open your bot with a parameter.
+  , answerCallbackQueryCacheTime :: Maybe Integer -- ^ The maximum amount of time in seconds that the result of the callback query may be cached client-side. Telegram apps will support caching starting in version 3.14. Defaults to 0.
+  }
+  deriving Generic
+
+instance ToJSON   AnswerCallbackQueryRequest where toJSON = gtoJSON
+instance FromJSON AnswerCallbackQueryRequest where parseJSON = gparseJSON
+
+type AnswerCallbackQuery = "answerCallbackQuery"
+  :> ReqBody '[JSON] AnswerCallbackQueryRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to send answers to callback 
+--   queries sent from inline keyboards. The answer 
+--   will be displayed to the user as a notification 
+--   at the top of the chat screen or as an alert. 
+--   On success, True is returned.
+--
+--  Alternatively, the user can be redirected to 
+--  the specified Game URL. For this option to work, 
+--  you must first create a game for your bot via 
+--  @Botfather and accept the terms. Otherwise, you 
+--  may use links like t.me/your_bot?start=XXXX that 
+--  open your bot with a parameter.
+answerCallbackQuery :: AnswerCallbackQueryRequest ->  ClientM (Response Bool)
+answerCallbackQuery = client (Proxy @AnswerCallbackQuery)

--- a/src/Telegram/Bot/API/Methods/ApproveChatJoinRequest.hs
+++ b/src/Telegram/Bot/API/Methods/ApproveChatJoinRequest.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.ApproveChatJoinRequest where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'approveChatJoinRequest'
+
+type ApproveChatJoinRequest = "approveChatJoinRequest"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> RequiredQueryParam "user_id" UserId
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to approve a chat 
+--   join request. The bot must be an 
+--   administrator in the chat for this 
+--   to work and must have the can_invite_users 
+--   administrator right. 
+--   Returns True on success.
+approveChatJoinRequest :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> UserId -- ^ Unique identifier of the target user
+  -> ClientM (Response Bool)
+approveChatJoinRequest = client (Proxy @ApproveChatJoinRequest)

--- a/src/Telegram/Bot/API/Methods/BanChatMember.hs
+++ b/src/Telegram/Bot/API/Methods/BanChatMember.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.BanChatMember where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'banChatMember'
+
+-- | Request parameters for 'banChatMember'.
+data BanChatMemberRequest = BanChatMemberRequest
+  { banChatMemberChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , banChatMemberUserId :: UserId -- ^ Unique identifier of the target user
+  , banChatMemberUntilDate :: Maybe Int -- ^ Date when the user will be unbanned, unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever. Applied for supergroups and channels only.
+  , banChatMemberRevokeMessages :: Maybe Bool -- ^ Pass True to delete all messages from the chat for the user that is being removed. If False, the user will be able to see messages in the group that were sent before the user was removed. Always True for supergroups and channels.
+  }
+  deriving Generic
+
+instance ToJSON   BanChatMemberRequest where toJSON = gtoJSON
+instance FromJSON BanChatMemberRequest where parseJSON = gparseJSON
+
+type BanChatMember = "banChatMember"
+  :> ReqBody '[JSON] BanChatMemberRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to ban a user in a
+--   group, a supergroup or a channel.
+--   In the case of supergroups and channels,
+--   the user will not be able to return to
+--   the chat on their own using invite links,
+--   etc., unless unbanned first. The bot must
+--   be an administrator in the chat for this
+--   to work and must have the appropriate
+--   administrator rights.
+--   Returns True on success.
+banChatMember :: BanChatMemberRequest ->  ClientM (Response Bool)
+banChatMember = client (Proxy @BanChatMember)

--- a/src/Telegram/Bot/API/Methods/BanChatSenderChat.hs
+++ b/src/Telegram/Bot/API/Methods/BanChatSenderChat.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.BanChatSenderChat where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'banChatSenderChat'
+
+type BanChatSenderChat = "banChatSenderChat"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> RequiredQueryParam "sender_chat_id" ChatId
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to ban a channel chat
+--   in a supergroup or a channel. Until the
+--   chat is unbanned, the owner of the banned
+--   chat won't be able to send messages on
+--   behalf of any of their channels. The bot
+--   must be an administrator in the supergroup
+--   or channel for this to work and must have
+--   the appropriate administrator rights.
+--   Returns True on success.
+banChatSenderChat :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ChatId -- ^ Unique identifier of the target sender chat
+  -> ClientM (Response  Bool)
+banChatSenderChat = client (Proxy @BanChatSenderChat)

--- a/src/Telegram/Bot/API/Methods/CopyMessage.hs
+++ b/src/Telegram/Bot/API/Methods/CopyMessage.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.CopyMessage where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+import Telegram.Bot.API.Types.ParseMode
+
+-- ** 'copyMessage'
+
+type CopyMessage
+  = "copyMessage"
+  :> ReqBody '[JSON] CopyMessageRequest
+  :> Post '[JSON] (Response CopyMessageId)
+
+-- | Use this method to copy messages of any kind.
+--   Service messages and invoice messages can't be
+--   copied. The method is analogous to the method
+--   forwardMessage, but the copied message doesn't
+--   have a link to the original message.
+--   Returns the MessageId of the sent message on success.
+copyMessage :: CopyMessageRequest ->  ClientM (Response CopyMessageId)
+copyMessage = client (Proxy @CopyMessage)
+
+-- | Request parameters for 'copyMessage'.
+data CopyMessageRequest = CopyMessageRequest
+  { copyMessageChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , copyMessageMessageThreadId :: Maybe Message -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , copyMessageFromChatId :: SomeChatId -- ^ Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
+  , copyMessageMessageId :: MessageId -- ^ Message identifier in the chat specified in from_chat_id
+  , copyMessageCaption :: Maybe Text -- ^ New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept
+  , copyMessageParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , copyMessageCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+  , copyMessageDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , copyMessageProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
+  , copyMessageReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , copyMessageAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , copyMessageReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON   CopyMessageRequest where toJSON = gtoJSON
+instance FromJSON CopyMessageRequest where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Methods/CreateChatInviteLink.hs
+++ b/src/Telegram/Bot/API/Methods/CreateChatInviteLink.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.CreateChatInviteLink where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'createChatInviteLink'
+
+-- | Request parameters for 'createChatInviteLink'.
+data CreateChatInviteLinkRequest = CreateChatInviteLinkRequest
+  { createChatInviteLinkChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , createChatInviteLinkName :: Maybe Text -- ^ Invite link name; 0-32 characters
+  , createChatInviteLinkExpireDate :: Maybe Integer -- ^ Point in time (Unix timestamp) when the link will expire
+  , createChatInviteLinkMemberLimit :: Maybe Int -- ^ Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
+  , createChatInviteLinkCreatesJoinRequest :: Maybe Bool -- ^ True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
+  }
+  deriving Generic
+
+instance ToJSON   CreateChatInviteLinkRequest where toJSON = gtoJSON
+instance FromJSON CreateChatInviteLinkRequest where parseJSON = gparseJSON
+
+type CreateChatInviteLink = "createChatInviteLink"
+  :> ReqBody '[JSON] CreateChatInviteLinkRequest
+  :> Post '[JSON] (Response ChatInviteLink)
+
+-- | Use this method to create an additional
+--   invite link for a chat. The bot must be 
+--   an administrator in the chat for this to 
+--   work and must have the appropriate administrator 
+--   rights. The link can be revoked using the 
+--   method revokeChatInviteLink. 
+--   Returns the new invite link as ChatInviteLink object.
+createChatInviteLink :: CreateChatInviteLinkRequest ->  ClientM (Response ChatInviteLink)
+createChatInviteLink = client (Proxy @CreateChatInviteLink)

--- a/src/Telegram/Bot/API/Methods/DeclineChatJoinRequest.hs
+++ b/src/Telegram/Bot/API/Methods/DeclineChatJoinRequest.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.DeclineChatJoinRequest where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'declineChatJoinRequest'
+
+type DeclineChatJoinRequest = "declineChatJoinRequest"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> RequiredQueryParam "user_id" UserId
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to decline a chat 
+--   join request. The bot must be an 
+--   administrator in the chat for this 
+--   to work and must have the can_invite_users 
+--   administrator right. 
+--   Returns True on success.
+declineChatJoinRequest :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> UserId -- ^ Unique identifier of the target user
+  -> ClientM (Response Bool)
+declineChatJoinRequest = client (Proxy @DeclineChatJoinRequest)

--- a/src/Telegram/Bot/API/Methods/DeleteChatPhoto.hs
+++ b/src/Telegram/Bot/API/Methods/DeleteChatPhoto.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.DeleteChatPhoto where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'deleteChatPhoto'
+
+type DeleteChatPhoto = "deleteChatPhoto"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to delete a chat photo.
+--   Photos can't be changed for private chats.
+--   The bot must be an administrator in the chat 
+--   for this to work and must have the appropriate 
+--   administrator rights. 
+--   Returns True on success.
+deleteChatPhoto :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ClientM (Response Bool)
+deleteChatPhoto = client (Proxy @DeleteChatPhoto)

--- a/src/Telegram/Bot/API/Methods/DeleteChatStickerSet.hs
+++ b/src/Telegram/Bot/API/Methods/DeleteChatStickerSet.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.DeleteChatStickerSet where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'deleteChatStickerSet'
+
+type DeleteChatStickerSet = "deleteChatStickerSet"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to delete a group sticker 
+--   set from a supergroup. The bot must be an 
+--   administrator in the chat for this to work 
+--   and must have the appropriate administrator 
+--   rights. Use the field can_set_sticker_set 
+--   optionally returned in getChat requests 
+--   to check if the bot can use this method. 
+--   Returns True on success.
+deleteChatStickerSet :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ClientM (Response Bool)
+deleteChatStickerSet = client (Proxy @DeleteChatStickerSet)

--- a/src/Telegram/Bot/API/Methods/DeleteMessage.hs
+++ b/src/Telegram/Bot/API/Methods/DeleteMessage.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.DeleteMessage where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'deleteMessage'
+
+-- | Notice that deleting by POST method was bugged, so we use GET
+type DeleteMessage = "deleteMessage"
+  :> RequiredQueryParam "chat_id" ChatId
+  :> RequiredQueryParam "message_id" MessageId
+  :> Get '[JSON] (Response Bool)
+
+-- | Use this method to delete message in chat.
+-- On success, the sent Bool is returned.
+deleteMessage :: ChatId -> MessageId -> ClientM (Response Bool)
+deleteMessage = client (Proxy @DeleteMessage)

--- a/src/Telegram/Bot/API/Methods/DeleteMyCommands.hs
+++ b/src/Telegram/Bot/API/Methods/DeleteMyCommands.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.DeleteMyCommands where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'deleteMyCommands'
+
+-- | Request parameters for 'deleteMyCommands'.
+data DeleteMyCommandsRequest = DeleteMyCommandsRequest
+  { deleteMyCommandsScope :: Maybe BotCommandScope  -- ^ A JSON-serialized object, describing scope of users. Defaults to BotCommandScopeDefault. 
+  , deleteMyCommandsLanguageCode :: Maybe Text  -- ^ 	A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
+  }
+  deriving Generic
+
+instance ToJSON   DeleteMyCommandsRequest where toJSON = gtoJSON
+instance FromJSON DeleteMyCommandsRequest where parseJSON = gparseJSON
+
+type DeleteMyCommands = "deleteMyCommands"
+  :> ReqBody '[JSON] DeleteMyCommandsRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to delete the list of 
+--   the bot's commands for the given scope 
+--   and user language. After deletion, higher 
+--   level commands will be shown to affected users. 
+--   Returns True on success.
+deleteMyCommands :: DeleteMyCommandsRequest -> ClientM (Response Bool)
+deleteMyCommands = client (Proxy @DeleteMyCommands)

--- a/src/Telegram/Bot/API/Methods/EditChatInviteLink.hs
+++ b/src/Telegram/Bot/API/Methods/EditChatInviteLink.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.EditChatInviteLink where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'editChatInviteLink'
+
+-- | Request parameters for 'editChatInviteLink'.
+data EditChatInviteLinkRequest = EditChatInviteLinkRequest
+  { editChatInviteLinkChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , editChatInviteLinkInviteLink :: Text -- ^	The invite link to edit
+  , editChatInviteLinkName :: Maybe Text -- ^ Invite link name; 0-32 characters
+  , editChatInviteLinkExpireDate :: Maybe Integer -- ^ Point in time (Unix timestamp) when the link will expire
+  , editChatInviteLinkMemberLimit :: Maybe Int -- ^ Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
+  , editChatInviteLinkCreatesJoinRequest :: Maybe Bool -- ^ True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
+  }
+  deriving Generic
+
+instance ToJSON   EditChatInviteLinkRequest where toJSON = gtoJSON
+instance FromJSON EditChatInviteLinkRequest where parseJSON = gparseJSON
+
+type EditChatInviteLink = "editChatInviteLink"
+  :> ReqBody '[JSON] EditChatInviteLinkRequest
+  :> Post '[JSON] (Response ChatInviteLink)
+
+-- | Use this method to edit a non-primary
+--   invite link created by the bot. The 
+--   bot must be an administrator in the 
+--   chat for this to work and must have 
+--   the appropriate administrator rights.
+--   Returns the edited invite link as a ChatInviteLink object.
+editChatInviteLink :: EditChatInviteLinkRequest ->  ClientM (Response ChatInviteLink)
+editChatInviteLink = client (Proxy @EditChatInviteLink)

--- a/src/Telegram/Bot/API/Methods/EditMessageLiveLocation.hs
+++ b/src/Telegram/Bot/API/Methods/EditMessageLiveLocation.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.EditMessageLiveLocation where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'editMessageLiveLocation'
+
+-- | Request parameters for 'editMessageLiveLocation'.
+data EditMessageLiveLocationRequest = EditMessageLiveLocationRequest
+  { editMessageLiveLocationChatId :: Maybe SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , editMessageLiveLocationMessageId :: Maybe MessageId -- ^ Required if inline_message_id is not specified. Identifier of the message with live location to stop
+  , editMessageLiveLocationInlineMessageId :: Maybe Text -- ^  	Required if chat_id and message_id are not specified. Identifier of the inline message
+  , editMessageLiveLocationLatitude :: Float -- ^ Latitude of new location
+  , editMessageLiveLocationLongitude :: Float -- ^ Longitude of new location
+  , editMessageLiveLocationHorizontalAccuracy :: Maybe Float -- ^ The radius of uncertainty for the location, measured in meters; 0-1500
+  , editMessageLiveLocationHeading :: Maybe Int -- ^ Direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+  , editMessageLiveLocationProximityAlertRadius :: Maybe Int  -- ^ Maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+  , editMessageLiveLocationReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON   EditMessageLiveLocationRequest where toJSON = gtoJSON
+instance FromJSON EditMessageLiveLocationRequest where parseJSON = gparseJSON
+
+type EditMessageLiveLocation = "editMessageLiveLocation"
+  :> ReqBody '[JSON] EditMessageLiveLocationRequest
+  :> Post '[JSON] (Response (Either Bool Message))
+
+-- | Use this method to edit live location messages.
+--   A location can be edited until its live_period
+--   expires or editing is explicitly disabled by a
+--   call to stopMessageLiveLocation. On success, if
+--   the edited message is not an inline message, the
+--   edited Message is returned, otherwise True is returned.
+editMessageLiveLocation :: EditMessageLiveLocationRequest ->  ClientM (Response (Either Bool Message))
+editMessageLiveLocation = client (Proxy @EditMessageLiveLocation)

--- a/src/Telegram/Bot/API/Methods/ExportChatInviteLink.hs
+++ b/src/Telegram/Bot/API/Methods/ExportChatInviteLink.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.ExportChatInviteLink where
+
+import Data.Proxy
+import Data.Text (Text)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'exportChatInviteLink'
+
+type ExportChatInviteLink = "exportChatInviteLink"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> Post '[JSON] (Response Text)
+
+-- | Use this method to generate a new
+--   primary invite link for a chat; any
+--   previously generated primary link is
+--   revoked. The bot must be an administrator
+--   in the chat for this to work and must have
+--   the appropriate administrator rights.
+--   Returns the new invite link as String on success.
+exportChatInviteLink :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ClientM (Response  Text)
+exportChatInviteLink = client (Proxy @ExportChatInviteLink)

--- a/src/Telegram/Bot/API/Methods/ForwardMessage.hs
+++ b/src/Telegram/Bot/API/Methods/ForwardMessage.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.ForwardMessage where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'forwardMessage'
+
+type ForwardMessage
+  = "forwardMessage" :> ReqBody '[JSON] ForwardMessageRequest :> Post '[JSON] (Response Message)
+
+-- | Use this method to forward messages of any kind.
+-- On success, the sent 'Message' is returned.
+
+forwardMessage :: ForwardMessageRequest -> ClientM (Response Message)
+forwardMessage = client (Proxy @ForwardMessage)
+
+
+-- | Request parameters for 'forwardMessage'.
+data ForwardMessageRequest = ForwardMessageRequest
+  { forwardMessageChatId              :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername).
+  , forwardMessageMessageThreadId     :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , forwardMessageFromChatId          :: SomeChatId -- ^ Unique identifier for the chat where the original message was sent (or channel username in the format @\@channelusername).
+  , forwardMessageDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , forwardMessageProtectContent      :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.
+  , forwardMessageMessageId           :: MessageId  -- ^ Message identifier in the chat specified in from_chat_id.
+  } deriving (Generic)
+
+instance ToJSON   ForwardMessageRequest where toJSON = gtoJSON
+instance FromJSON ForwardMessageRequest where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Methods/GetChat.hs
+++ b/src/Telegram/Bot/API/Methods/GetChat.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetChat where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getChat'
+
+type GetChat = "getChat"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> Post '[JSON] (Response Chat)
+
+-- | Use this method to get up to date information 
+--   about the chat (current name of the user for 
+--   one-on-one conversations, current username of 
+--   a user, group or channel, etc.). 
+--   Returns a Chat object on success.
+getChat :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ClientM (Response Chat)
+getChat = client (Proxy @GetChat)

--- a/src/Telegram/Bot/API/Methods/GetChatAdministrators.hs
+++ b/src/Telegram/Bot/API/Methods/GetChatAdministrators.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetChatAdministrators where
+
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getChatAdministrators'
+
+type GetChatAdministrators = "getChatAdministrators"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> Post '[JSON] (Response [ChatMember])
+
+-- | Use this method to get a list of administrators
+--   in a chat. On success, returns an Array of 
+--   ChatMember objects that contains information 
+--   about all chat administrators except other bots. 
+--   If the chat is a group or a supergroup and no 
+--   administrators were appointed, only the creator 
+--   will be returned.
+getChatAdministrators :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ClientM (Response [ChatMember])
+getChatAdministrators = client (Proxy @GetChatAdministrators)

--- a/src/Telegram/Bot/API/Methods/GetChatMember.hs
+++ b/src/Telegram/Bot/API/Methods/GetChatMember.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetChatMember where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getChatMember'
+
+type GetChatMember = "getChatMember"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> RequiredQueryParam "user_id" UserId
+  :> Post '[JSON] (Response ChatMember)
+
+-- | Use this method to get information about a member of a chat. 
+--   Returns a ChatMember object on success.
+getChatMember :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> UserId -- ^ 	Unique identifier of the target user
+  -> ClientM (Response ChatMember)
+getChatMember = client (Proxy @GetChatMember)

--- a/src/Telegram/Bot/API/Methods/GetChatMemberCount.hs
+++ b/src/Telegram/Bot/API/Methods/GetChatMemberCount.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetChatMemberCount where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getChatMemberCount'
+
+type GetChatMemberCount = "getChatMemberCount"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> Post '[JSON] (Response Integer)
+
+-- | Use this method to get the number of members in a chat. 
+--   Returns Int on success.
+getChatMemberCount :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ClientM (Response Integer)
+getChatMemberCount = client (Proxy @GetChatMemberCount)

--- a/src/Telegram/Bot/API/Methods/GetChatMenuButton.hs
+++ b/src/Telegram/Bot/API/Methods/GetChatMenuButton.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetChatMenuButton where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getChatMenuButton'
+
+-- | Request parameters for 'getChatMenuButton'.
+data GetChatMenuButtonRequest = GetChatMenuButtonRequest
+  { getChatMenuButtonRequestChatId     :: Maybe ChatId     -- ^ Unique identifier for the target private chat. If not specified, default bot's menu button will be returned.
+  }
+  deriving Generic
+
+instance ToJSON   GetChatMenuButtonRequest where toJSON = gtoJSON
+instance FromJSON GetChatMenuButtonRequest where parseJSON = gparseJSON
+
+type GetChatMenuButton = "getChatMenuButton"
+  :> ReqBody '[JSON] GetChatMenuButtonRequest
+  :> Post '[JSON] (Response MenuButton)
+
+-- | Use this method to get the current value
+--  of the bot's menu button in a private chat, or the default menu button.
+-- Returns @MenuButton@ on success.
+getChatMenuButton :: GetChatMenuButtonRequest -> ClientM (Response MenuButton)
+getChatMenuButton = client (Proxy @GetChatMenuButton)

--- a/src/Telegram/Bot/API/Methods/GetFile.hs
+++ b/src/Telegram/Bot/API/Methods/GetFile.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetFile where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getFile'
+
+type GetFile
+  = "getFile"
+  :> RequiredQueryParam "file_id" FileId
+  :> Get '[JSON] (Response File)
+
+getFile :: FileId -> ClientM (Response File)
+getFile = client (Proxy @GetFile)

--- a/src/Telegram/Bot/API/Methods/GetMe.hs
+++ b/src/Telegram/Bot/API/Methods/GetMe.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetMe where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getMe'
+
+type GetMe = "getMe" :> Get '[JSON] (Response User)
+
+-- | A simple method for testing your bot's auth token.
+-- Requires no parameters.
+-- Returns basic information about the bot in form of a 'User' object.
+getMe :: ClientM (Response User)
+getMe = client (Proxy @GetMe)

--- a/src/Telegram/Bot/API/Methods/GetMyCommands.hs
+++ b/src/Telegram/Bot/API/Methods/GetMyCommands.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetMyCommands where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getMyCommands'
+
+-- | Request parameters for 'getMyCommands'.
+data GetMyCommandsRequest = GetMyCommandsRequest
+  { getMyCommandsScope :: Maybe BotCommandScope  -- ^ A JSON-serialized object, describing scope of users. Defaults to BotCommandScopeDefault. 
+  , getMyCommandsLanguageCode :: Maybe Text   -- ^ 	A two-letter ISO 639-1 language code or an empty string
+  }
+  deriving Generic
+
+instance ToJSON   GetMyCommandsRequest where toJSON = gtoJSON
+instance FromJSON GetMyCommandsRequest where parseJSON = gparseJSON
+
+type GetMyCommands = "getMyCommands"
+  :> ReqBody '[JSON] GetMyCommandsRequest
+  :> Post '[JSON] (Response [BotCommand])
+
+-- | Use this method to get the current list
+--   of the bot's commands for the given scope 
+--   and user language. Returns Array of BotCommand 
+--   on success. If commands aren't set, an empty list 
+--   is returned.
+getMyCommands :: GetMyCommandsRequest -> ClientM (Response [BotCommand])
+getMyCommands = client (Proxy @GetMyCommands)

--- a/src/Telegram/Bot/API/Methods/GetMyDefaultAdministratorRights.hs
+++ b/src/Telegram/Bot/API/Methods/GetMyDefaultAdministratorRights.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetMyDefaultAdministratorRights where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getMyDefaultAdministratorRights'
+
+-- | Request parameters for 'getMyDefaultAdministratorRights'.
+data GetMyDefaultAdministratorRightsRequest = GetMyDefaultAdministratorRightsRequest
+  { getMyDefaultAdministratorRightsRequestForChannels :: Maybe Bool -- ^ Pass 'True' to get default administrator rights of the bot in channels. Otherwise, default administrator rights of the bot for groups and supergroups will be returned.
+  }
+  deriving Generic
+
+instance ToJSON   GetMyDefaultAdministratorRightsRequest where toJSON = gtoJSON
+instance FromJSON GetMyDefaultAdministratorRightsRequest where parseJSON = gparseJSON
+
+type GetMyDefaultAdministratorRights = "getMyDefaultAdministratorRights"
+  :> ReqBody '[JSON] GetMyDefaultAdministratorRightsRequest
+  :> Post '[JSON] (Response ChatAdministratorRights)
+
+-- | Use this method to get the current default administrator rights of the bot.
+-- Returns 'ChatAdministratorRights' on success.
+getMyDefaultAdministratorRights
+  :: GetMyDefaultAdministratorRightsRequest -> ClientM (Response ChatAdministratorRights)
+getMyDefaultAdministratorRights = client (Proxy @GetMyDefaultAdministratorRights)

--- a/src/Telegram/Bot/API/Methods/GetUserProfilePhotos.hs
+++ b/src/Telegram/Bot/API/Methods/GetUserProfilePhotos.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.GetUserProfilePhotos where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'getUserProfilePhotos'
+
+-- | Request parameters for 'getUserProfilePhotos'.
+data GetUserProfilePhotosRequest = GetUserProfilePhotosRequest
+  { getUserProfilePhotosUserId :: UserId -- ^ Unique identifier of the target user
+  , getUserProfilePhotosOffset :: Maybe Int -- ^ Sequential number of the first photo to be returned. By default, all photos are returned.
+  , getUserProfilePhotosLimit :: Maybe Int -- ^ Limits the number of photos to be retrieved. Values between 1-100 are accepted. Defaults to 100.
+  }
+  deriving Generic
+
+instance ToJSON   GetUserProfilePhotosRequest where toJSON = gtoJSON
+instance FromJSON GetUserProfilePhotosRequest where parseJSON = gparseJSON
+
+type GetUserProfilePhotos = "getUserProfilePhotos"
+  :> ReqBody '[JSON] GetUserProfilePhotosRequest
+  :> Post '[JSON] (Response UserProfilePhotos)
+
+-- | Use this method to get a list of profile pictures for a user.
+--   Returns a UserProfilePhotos object.
+getUserProfilePhotos :: GetUserProfilePhotosRequest ->  ClientM (Response UserProfilePhotos)
+getUserProfilePhotos = client (Proxy @GetUserProfilePhotos)

--- a/src/Telegram/Bot/API/Methods/LeaveChat.hs
+++ b/src/Telegram/Bot/API/Methods/LeaveChat.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.LeaveChat where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'leaveChat'
+
+type LeaveChat = "leaveChat"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method for your bot to leave a group, supergroup or channel. 
+--   Returns True on success.
+leaveChat :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ClientM (Response Bool)
+leaveChat = client (Proxy @LeaveChat)

--- a/src/Telegram/Bot/API/Methods/PinChatMessage.hs
+++ b/src/Telegram/Bot/API/Methods/PinChatMessage.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.PinChatMessage where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'pinChatMessage'
+
+-- | Request parameters for 'pinChatMessage'.
+data PinChatMessageRequest = PinChatMessageRequest
+  { pinChatMessageChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , pinChatMessageMessageId :: MessageId -- ^ Identifier of a message to pin
+  , pinChatMessageDisableNotification :: Maybe Bool -- ^ Pass True, if it is not necessary to send a notification to all chat members about the new pinned message. Notifications are always disabled in channels and private chats.
+  }
+  deriving Generic
+
+instance ToJSON   PinChatMessageRequest where toJSON = gtoJSON
+instance FromJSON PinChatMessageRequest where parseJSON = gparseJSON
+
+type PinChatMessage = "pinChatMessage"
+  :> ReqBody '[JSON] PinChatMessageRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to add a message to the list 
+--   of pinned messages in a chat. If the chat is 
+--   not a private chat, the bot must be an administrator 
+--   in the chat for this to work and must have the 
+--   'can_pin_messages' administrator right in a supergroup
+--   or 'can_edit_messages' administrator right in a channel. 
+--   Returns True on success.
+pinChatMessage :: PinChatMessageRequest ->  ClientM (Response Bool)
+pinChatMessage = client (Proxy @PinChatMessage)

--- a/src/Telegram/Bot/API/Methods/PromoteChatMember.hs
+++ b/src/Telegram/Bot/API/Methods/PromoteChatMember.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.PromoteChatMember where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'promoteChatMember'
+
+-- | Request parameters for 'promoteChatMember'.
+data PromoteChatMemberRequest = PromoteChatMemberRequest
+  { promoteChatMemberChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , promoteChatMemberUserId :: UserId -- ^ Unique identifier of the target user.
+  , promoteChatMemberIsAnonymous :: Maybe Bool -- ^ Pass 'True', if the administrator's presence in the chat is hidden.
+  , promoteChatMemberCanManageChat :: Maybe Bool -- ^ Pass 'True', if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege.
+  , promoteChatMemberCanPostMessages :: Maybe Bool -- ^ Pass 'True', if the administrator can create channel posts, channels only.
+  , promoteChatMemberCanEditMessages :: Maybe Bool -- ^ Pass 'True', if the administrator can edit messages of other users and can pin messages, channels only.
+  , promoteChatMemberCanDeleteMessages :: Maybe Bool -- ^ Pass 'True', if the administrator can delete messages of other users.
+  , promoteChatMemberCanManageVideoChats :: Maybe Bool -- ^ Pass 'True', if the administrator can manage video chats.
+  , promoteChatMemberCanRestrictMembers :: Maybe Bool -- ^ Pass 'True', if the administrator can restrict, ban or unban chat members.
+  , promoteChatMemberCanPromoteMembers :: Maybe Bool -- ^ Pass 'True', if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him).
+  , promoteChatMemberCanChangeInfo :: Maybe Bool -- ^ Pass 'True', if the administrator can change chat title, photo and other settings.
+  , promoteChatMemberCanInviteUsers :: Maybe Bool -- ^ Pass 'True', if the administrator can invite new users to the chat.
+  , promoteChatMemberCanPinMessages :: Maybe Bool -- ^ Pass 'True', if the administrator can pin messages, supergroups only.
+  , promoteChatMemberCanManageTopics :: Maybe Bool -- ^ Pass 'True', if the user is allowed to create, rename, close, and reopen forum topics, supergroups only.
+  }
+  deriving Generic
+
+instance ToJSON   PromoteChatMemberRequest where toJSON = gtoJSON
+instance FromJSON PromoteChatMemberRequest where parseJSON = gparseJSON
+
+type PromoteChatMember = "promoteChatMember"
+  :> ReqBody '[JSON] PromoteChatMemberRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to promote or demote
+--   a user in a supergroup or a channel.
+--   The bot must be an administrator in
+--   the chat for this to work and must have
+--   the appropriate administrator rights.
+--   Pass False for all boolean parameters
+--   to demote a user.
+--   Returns True on success.
+promoteChatMember ::PromoteChatMemberRequest ->  ClientM (Response Bool)
+promoteChatMember = client (Proxy @PromoteChatMember)

--- a/src/Telegram/Bot/API/Methods/RestrictChatMember.hs
+++ b/src/Telegram/Bot/API/Methods/RestrictChatMember.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.RestrictChatMember where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'restrictChatMember'
+
+-- | Request parameters for 'restrictChatMember'.
+data RestrictChatMemberRequest = RestrictChatMemberRequest
+  { restrictChatMemberChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , restrictChatMemberUserId :: UserId -- ^ Unique identifier of the target user.
+  , restrictChatMemberPermissions :: ChatPermissions -- ^ A JSON-serialized object for new user permissions.
+  , restrictChatMemberUseIndependentChatPermissions :: Maybe Bool -- ^ Pass 'True' if chat permissions are set independently. Otherwise, the @can_send_other_messages@ and @can_add_web_page_previews@ permissions will imply the @can_send_messages@, @can_send_audios@, @can_send_documents@, @can_send_photos@, @can_send_videos@, @can_send_video_notes@, and @can_send_voice_notes@ permissions; the @can_send_polls@ permission will imply the @can_send_messages@ permission.
+  , restrictChatMemberUntilDate :: Maybe Int -- ^ Date when restrictions will be lifted for the user, unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever.
+  }
+  deriving Generic
+
+instance ToJSON   RestrictChatMemberRequest where toJSON = gtoJSON
+instance FromJSON RestrictChatMemberRequest where parseJSON = gparseJSON
+
+type RestrictChatMember = "restrictChatMember"
+  :> ReqBody '[JSON] RestrictChatMemberRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to restrict a user
+--   in a supergroup. The bot must be an
+--   administrator in the supergroup for
+--   this to work and must have the appropriate
+--   administrator rights. Pass True for all
+--   permissions to lift restrictions from a
+--   user.
+--   Returns True on success.
+restrictChatMember :: RestrictChatMemberRequest ->  ClientM (Response Bool)
+restrictChatMember = client (Proxy @RestrictChatMember)

--- a/src/Telegram/Bot/API/Methods/RevokeChatInviteLink.hs
+++ b/src/Telegram/Bot/API/Methods/RevokeChatInviteLink.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.RevokeChatInviteLink where
+
+import Data.Proxy
+import Data.Text (Text)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'revokeChatInviteLink'
+
+type RevokeChatInviteLink = "revokeChatInviteLink"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> RequiredQueryParam "invite_link" Text
+  :> Post '[JSON] (Response ChatInviteLink)
+
+-- | Use this method to revoke an invite
+--   link created by the bot. If the primary 
+--   link is revoked, a new link is automatically 
+--   generated. The bot must be an administrator 
+--   in the chat for this to work and must have 
+--   the appropriate administrator rights. 
+--   Returns the revoked invite link as ChatInviteLink object.
+revokeChatInviteLink :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> Text -- ^ The invite link to revoke
+  -> ClientM (Response  ChatInviteLink)
+revokeChatInviteLink = client (Proxy @RevokeChatInviteLink)

--- a/src/Telegram/Bot/API/Methods/SendAnimation.hs
+++ b/src/Telegram/Bot/API/Methods/SendAnimation.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendAnimation where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (ToJSON (..))
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Bool
+import Data.Maybe (catMaybes)
+import Data.Functor ((<&>))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Multipart.API
+import Servant.Multipart.Client
+import Servant.Client hiding (Response)
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+import Telegram.Bot.API.Types.ParseMode
+
+-- ** 'sendAnimation'
+
+-- | Request parameters for 'sendAnimation'.
+data SendAnimationRequest = SendAnimationRequest
+  { sendAnimationChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , sendAnimationMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendAnimationAnimation :: InputFile -- ^ Animation to send. Pass a file_id as String to send an animation that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an animation from the Internet, or upload a new animation using multipart/form-data. More info on Sending Files »
+  , sendAnimationDuration :: Maybe Int -- ^ Duration of sent animation in seconds
+  , sendAnimationWidth :: Maybe Int -- ^ Animation width
+  , sendAnimationHeight :: Maybe Int -- ^ Animation height
+  , sendAnimationThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+  , sendAnimationCaption :: Maybe Text -- ^ Animation caption (may also be used when resending animation by file_id), 0-1024 characters after entities parsing
+  , sendAnimationParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , sendAnimationCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+  , sendAnimationHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the animation needs to be covered with a spoiler animation.
+  , sendAnimationDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendAnimationProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.
+  , sendAnimationReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message.
+  , sendAnimationAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found.
+  , sendAnimationReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON SendAnimationRequest where toJSON = gtoJSON
+
+instance ToMultipart Tmp SendAnimationRequest where
+  toMultipart SendAnimationRequest{..} =
+    maybe id (makeFile "thumb") sendAnimationThumb $
+    makeFile "animation" sendAnimationAnimation $
+    MultipartData fields [] where
+    fields =
+      [ Input "chat_id" $ case sendAnimationChatId of
+          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
+          SomeChatUsername txt -> txt
+      ] <> catMaybes
+      [ sendAnimationMessageThreadId <&>
+        \t -> Input "message_thread_id" (T.pack $ show t)
+      , sendAnimationCaption <&>
+        \t -> Input "caption" t
+      , sendAnimationParseMode <&>
+        \t -> Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)
+      , sendAnimationCaptionEntities <&>
+        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
+      , sendAnimationHasSpoiler <&>
+        \t -> Input "has_spoiler" (bool "false" "true" t)
+      , sendAnimationDuration <&>
+        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
+      , sendAnimationWidth <&>
+        \t -> Input "width" (TL.toStrict $ encodeToLazyText t)
+      , sendAnimationHeight <&>
+        \t -> Input "height" (TL.toStrict $ encodeToLazyText t)
+      , sendAnimationDisableNotification <&>
+        \t -> Input "disable_notification" (bool "false" "true" t)
+      , sendAnimationProtectContent <&>
+        \t -> Input "protect_content" (bool "false" "true" t)
+      , sendAnimationReplyToMessageId <&>
+        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
+      , sendAnimationAllowSendingWithoutReply <&>
+        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
+      , sendAnimationReplyMarkup <&>
+        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
+      ]
+
+type SendAnimationContent
+  = "sendAnimation"
+  :> MultipartForm Tmp SendAnimationRequest
+  :> Post '[JSON] (Response Message)
+
+type SendAnimationLink
+  = "sendAnimation"
+  :> ReqBody '[JSON] SendAnimationRequest
+  :> Post '[JSON] (Response Message)
+
+
+-- | Use this method to send animation files
+--   (GIF or H.264/MPEG-4 AVC video without sound).
+--   On success, the sent Message is returned. Bots
+--   can currently send animation files of up to 50
+--   MB in size, this limit may be changed in the future.
+sendAnimation :: SendAnimationRequest ->  ClientM (Response Message)
+sendAnimation r = case (sendAnimationAnimation r, sendAnimationThumb r) of
+  (InputFile{}, _) -> do
+    boundary <- liftIO genBoundary
+    client (Proxy @SendAnimationContent) (boundary, r)
+  (_, Just InputFile{}) -> do
+    boundary <- liftIO genBoundary
+    client (Proxy @SendAnimationContent) (boundary, r)
+  _ ->  client (Proxy @SendAnimationLink) r

--- a/src/Telegram/Bot/API/Methods/SendAudio.hs
+++ b/src/Telegram/Bot/API/Methods/SendAudio.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendAudio where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (ToJSON (..))
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Bool
+import Data.Maybe (catMaybes)
+import Data.Functor ((<&>))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Multipart.API
+import Servant.Multipart.Client
+import Servant.Client hiding (Response)
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+import Telegram.Bot.API.Types.ParseMode
+
+-- ** 'sendAudio'
+
+-- | Request parameters for 'sendAudio'.
+data SendAudioRequest = SendAudioRequest
+  { sendAudioChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendAudioMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendAudioAudio :: InputFile -- ^ Audio to send. Pass a file_id as String to send an audio that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a audio from the Internet, or upload a new audio using multipart/form-data. More info on Sending Files »
+  , sendAudioDuration :: Maybe Int -- ^ Duration of sent audio in seconds
+  , sendAudioPerformer :: Maybe Text -- ^ Performer
+  , sendAudioTitle :: Maybe Text -- ^ Track name
+  , sendAudioThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+  , sendAudioCaption :: Maybe Text -- ^ Audio caption (may also be used when resending audios by file_id), 0-1024 characters after entities parsing
+  , sendAudioParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , sendAudioCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+  , sendAudioDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendAudioProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
+  , sendAudioReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendAudioAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendAudioReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON SendAudioRequest where toJSON = gtoJSON
+
+instance ToMultipart Tmp SendAudioRequest where
+  toMultipart SendAudioRequest{..} =
+    maybe id (makeFile "thumb") sendAudioThumb $
+    makeFile "audio" sendAudioAudio $
+    MultipartData fields [] where
+    fields =
+      [ Input "chat_id" $ case sendAudioChatId of
+          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
+          SomeChatUsername txt -> txt
+      ] <> catMaybes
+      [ sendAudioMessageThreadId <&>
+        \t -> Input "message_thread_id" (T.pack $ show t)
+      , sendAudioCaption <&>
+        \t -> Input "caption" t
+      , sendAudioParseMode <&>
+        \t -> Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)
+      , sendAudioCaptionEntities <&>
+        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
+      , sendAudioDuration <&>
+        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
+      , sendAudioPerformer <&>
+        \t -> Input "performer" t
+      , sendAudioTitle <&>
+        \t -> Input "title" (TL.toStrict $ encodeToLazyText t)
+      , sendAudioDisableNotification <&>
+        \t -> Input "disable_notification" (bool "false" "true" t)
+      , sendAudioProtectContent <&>
+        \t -> Input "protect_content" (bool "false" "true" t)
+      , sendAudioReplyToMessageId <&>
+        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
+      , sendAudioAllowSendingWithoutReply <&>
+        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
+      , sendAudioReplyMarkup <&>
+        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
+      ]
+
+type SendAudioContent
+  = "sendAudio"
+  :> MultipartForm Tmp SendAudioRequest
+  :> Post '[JSON] (Response Message)
+
+type SendAudioLink
+  = "sendAudio"
+  :> ReqBody '[JSON] SendAudioRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send audio files, if
+--   you want Telegram clients to display them
+--   in the music player. Your audio must be in
+--   the .MP3 or .M4A format. On success, the sent
+--   Message is returned. Bots can currently send
+--   audio files of up to 50 MB in size, this limit
+--   may be changed in the future.
+--
+--   For sending voice messages, use the sendVoice method instead.
+sendAudio :: SendAudioRequest ->  ClientM (Response Message)
+sendAudio r = case (sendAudioAudio r, sendAudioThumb r) of
+  (InputFile{}, _) -> do
+    boundary <- liftIO genBoundary
+    client (Proxy @SendAudioContent) (boundary, r)
+  (_, Just InputFile{}) -> do
+    boundary <- liftIO genBoundary
+    client (Proxy @SendAudioContent) (boundary, r)
+  _ ->  client (Proxy @SendAudioLink) r

--- a/src/Telegram/Bot/API/Methods/SendChatAction.hs
+++ b/src/Telegram/Bot/API/Methods/SendChatAction.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendChatAction where
+
+import Data.Proxy
+import Data.Text (Text)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+type SendChatAction = "sendChatAction"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> QueryParam "message_thread_id" MessageThreadId
+  :> RequiredQueryParam "action" Text
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method when you need to tell the
+--   user that something is happening on the bot's side.
+--   The status is set for 5 seconds or less
+--   (when a message arrives from your bot, Telegram
+--   clients clear its typing status).
+--   Returns True on success.
+--
+--   Example: The ImageBot needs some time to
+--   process a request and upload the image.
+--   Instead of sending a text message along
+--   the lines of “Retrieving image, please wait…”,
+--   the bot may use sendChatAction with action = upload_photo.
+--   The user will see a “sending photo” status for the bot.
+--
+--   We only recommend using this method when a
+--   response from the bot will take a noticeable
+--   amount of time to arrive.
+sendChatAction :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
+  -> Maybe MessageThreadId -- ^ Unique identifier for the target message thread; supergroups only.
+  -> Text -- ^ Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes.
+  -> ClientM (Response  Bool)
+sendChatAction = client (Proxy @SendChatAction)

--- a/src/Telegram/Bot/API/Methods/SendContact.hs
+++ b/src/Telegram/Bot/API/Methods/SendContact.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendContact where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'sendContact'
+
+-- | Request parameters for 'sendContact'.
+data SendContactRequest = SendContactRequest
+  { sendContactChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendContactMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendContactPhoneNumber :: Text -- ^ Contact's phone number
+  , sendContactFirstName  :: Text -- ^ Contact's first name
+  , sendContactLastName  :: Text -- ^ Contact's last name
+  , sendContactVcard  :: Text -- ^ Additional data about the contact in the form of a vCard, 0-2048 bytes
+  , sendContactDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendContactProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
+  , sendContactReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendContactAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendContactReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON   SendContactRequest where toJSON = gtoJSON
+instance FromJSON SendContactRequest where parseJSON = gparseJSON
+
+type SendContact = "sendContact"
+  :> ReqBody '[JSON] SendContactRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send phone contacts.
+--   On success, the sent Message is returned.
+sendContact :: SendContactRequest ->  ClientM (Response Message)
+sendContact = client (Proxy @SendContact)

--- a/src/Telegram/Bot/API/Methods/SendDice.hs
+++ b/src/Telegram/Bot/API/Methods/SendDice.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendDice where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'sendDice'
+
+-- | Request parameters for 'sendDice'.
+data SendDiceRequest = SendDiceRequest
+  { sendDiceChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendDiceMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendDiceEmoji :: Maybe Text -- ^ Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, “🏀”, “⚽”, “🎳”, or “🎰”. Dice can have values 1-6 for “🎲”, “🎯” and “🎳”, values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”. Defaults to “🎲”
+  , sendDiceDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendDiceProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding
+  , sendDiceReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendDiceAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendDiceReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON   SendDiceRequest where toJSON = gtoJSON
+instance FromJSON SendDiceRequest where parseJSON = gparseJSON
+
+type SendDice = "sendDice"
+  :> ReqBody '[JSON] SendDiceRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send an animated emoji that
+--   will display a random value.
+--   On success, the sent Message is returned.
+sendDice :: SendDiceRequest ->  ClientM (Response Message)
+sendDice = client (Proxy @SendDice)

--- a/src/Telegram/Bot/API/Methods/SendDocument.hs
+++ b/src/Telegram/Bot/API/Methods/SendDocument.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendDocument where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (ToJSON (..))
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Bool
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Multipart.API
+import Servant.Multipart.Client
+import System.FilePath
+import Servant.Client hiding (Response)
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+import Telegram.Bot.API.Types.ParseMode
+import Telegram.Bot.API.Types.SomeReplyMarkup
+
+-- ** 'sendDocument'
+
+type SendDocumentContent
+  = "sendDocument"
+  :> MultipartForm Tmp SendDocumentRequest
+  :> Post '[JSON] (Response Message)
+
+type SendDocumentLink
+  = "sendDocument"
+  :> ReqBody '[JSON] SendDocumentRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send text messages.
+-- On success, the sent 'Message' is returned.
+--
+-- <https:\/\/core.telegram.org\/bots\/api#senddocument>
+sendDocument :: SendDocumentRequest -> ClientM (Response Message)
+sendDocument r = do
+  case sendDocumentDocument r of
+    DocumentFile{} -> do
+      boundary <- liftIO genBoundary
+      client (Proxy @SendDocumentContent) (boundary, r)
+    _ -> client (Proxy @SendDocumentLink) r
+
+-- | Request parameters for 'sendDocument'
+data SendDocumentRequest = SendDocumentRequest
+  { sendDocumentChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername@).
+  , sendDocumentMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendDocumentDocument :: DocumentFile -- ^ Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data
+  , sendDocumentThumb :: Maybe FilePath -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>
+  , sendDocumentCaption :: Maybe Text -- ^ Document caption (may also be used when resending documents by file_id), 0-1024 characters after entities parsing
+  , sendDocumentParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , sendDocumentCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of /parse_mode/.
+  , sendDocumentDisableContentTypeDetection :: Maybe Bool -- ^ Disables automatic server-side content type detection for files uploaded using @multipart/form-data@.
+  , sendDocumentDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendDocumentProtectContent      :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.  
+  , sendDocumentReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message.
+  , sendDocumentAllowSendingWithoutReply :: Maybe Bool -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found.
+  , sendDocumentReplyMarkup :: Maybe SomeReplyMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+
+newtype DocumentFile = MakeDocumentFile InputFile
+  deriving newtype ToJSON
+
+pattern DocumentFileId :: FileId -> DocumentFile
+pattern DocumentFileId x = MakeDocumentFile (InputFileId x)
+
+pattern DocumentUrl :: Text -> DocumentFile
+pattern DocumentUrl x = MakeDocumentFile (FileUrl x)
+
+pattern DocumentFile :: FilePath -> ContentType -> DocumentFile
+pattern DocumentFile x y = MakeDocumentFile (InputFile x y)
+
+
+instance ToMultipart Tmp SendDocumentRequest where
+  toMultipart SendDocumentRequest{..} = MultipartData fields files where
+    fields =
+      [ Input "document" $ T.pack $ "attach://file"
+      , Input "chat_id" $ case sendDocumentChatId of
+          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
+          SomeChatUsername txt -> txt
+      ] <>
+      (   (maybe id (\t -> ((Input "message_thread_id") (T.pack $ show t):)) sendDocumentMessageThreadId)
+        $ (maybe id (\_ -> ((Input "thumb" "attach://thumb"):)) sendDocumentThumb)
+        $ (maybe id (\t -> ((Input "caption" t):)) sendDocumentCaption)
+        $ (maybe id (\t -> ((Input "parse_mode" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentParseMode)
+        $ (maybe id (\t -> ((Input "caption_entities" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentCaptionEntities)
+        $ (maybe id (\t -> ((Input "disable_notification" (bool "false" "true" t)):)) sendDocumentDisableNotification)
+        $ (maybe id (\t -> ((Input "disable_content_type_detection" (bool "false" "true" t)):)) sendDocumentDisableContentTypeDetection)
+        $ (maybe id (\t -> ((Input "protect_content" (bool "false" "true" t)):)) sendDocumentProtectContent)
+        $ (maybe id (\t -> ((Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentReplyToMessageId)
+        $ (maybe id (\t -> ((Input "allow_sending_without_reply" (bool "false" "true" t)):)) sendDocumentAllowSendingWithoutReply)
+        $ (maybe id (\t -> ((Input "reply_markup" (TL.toStrict $ encodeToLazyText t)):)) sendDocumentReplyMarkup)
+        [])
+    files
+      = (FileData "file" (T.pack $ takeFileName path) ct path)
+      : maybe [] (\t -> [FileData "thumb" (T.pack $ takeFileName t) "image/jpeg" t]) sendDocumentThumb
+
+    DocumentFile path ct = sendDocumentDocument
+
+
+instance ToJSON   SendDocumentRequest where toJSON = gtoJSON
+
+-- | Generate send document structure.
+toSendDocument :: SomeChatId -> DocumentFile -> SendDocumentRequest
+toSendDocument ch df = SendDocumentRequest
+  { sendDocumentChatId = ch
+  , sendDocumentMessageThreadId = Nothing
+  , sendDocumentDocument = df
+  , sendDocumentThumb = Nothing
+  , sendDocumentCaption = Nothing
+  , sendDocumentParseMode = Nothing
+  , sendDocumentCaptionEntities =  Nothing
+  , sendDocumentDisableContentTypeDetection = Nothing
+  , sendDocumentDisableNotification = Nothing
+  , sendDocumentProtectContent = Nothing
+  , sendDocumentReplyToMessageId = Nothing
+  , sendDocumentAllowSendingWithoutReply = Nothing
+  , sendDocumentReplyMarkup = Nothing
+  }

--- a/src/Telegram/Bot/API/Methods/SendLocation.hs
+++ b/src/Telegram/Bot/API/Methods/SendLocation.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendLocation where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'sendLocation'
+
+-- | Request parameters for 'sendLocation'.
+data SendLocationRequest = SendLocationRequest
+  { sendLocationChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendLocationMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendLocationLatitude :: Float -- ^ Latitude of new location
+  , sendLocationLongitude :: Float -- ^ Longitude of new location
+  , sendLocationHorizontalAccuracy :: Maybe Float -- ^ The radius of uncertainty for the location, measured in meters; 0-1500
+  , sendLocationLivePeriod :: Int -- ^ Period in seconds for which the location will be updated (see Live Locations, should be between 60 and 86400.)
+  , sendLocationHeading :: Maybe Int -- ^ Direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+  , sendLocationProximityAlertRadius :: Maybe Int  -- ^ Maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+  , sendLocationDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendLocationProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
+  , sendLocationReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendLocationAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendLocationReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON   SendLocationRequest where toJSON = gtoJSON
+instance FromJSON SendLocationRequest where parseJSON = gparseJSON
+
+
+type SendLocation = "sendLocation"
+  :> ReqBody '[JSON] SendLocationRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send point on the map.
+--   On success, the sent Message is returned.
+sendLocation :: SendLocationRequest ->  ClientM (Response Message)
+sendLocation = client (Proxy @SendLocation)

--- a/src/Telegram/Bot/API/Methods/SendMediaGroup.hs
+++ b/src/Telegram/Bot/API/Methods/SendMediaGroup.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendMediaGroup where
+
+import Data.Aeson (ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'sendMediaGroup'
+
+-- | Request parameters for 'sendMediaGroup'.
+data SendMediaGroupRequest = SendMediaGroupRequest
+  { sendMediaGroupChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendMediaGroupMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendMediaGroupMedia :: [InputMedia] -- ^ A JSON-serialized array describing messages to be sent, must include 2-10 items. InputMediaAudio, InputMediaDocument, InputMediaPhoto or InputMediaVideo.
+  , sendMediaGroupDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendMediaGroupProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
+  , sendMediaGroupReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendMediaGroupAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendMediaGroupReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON SendMediaGroupRequest where toJSON = gtoJSON
+
+type SendMediaGroup = "sendMediaGroup"
+  :> ReqBody '[JSON] SendMediaGroupRequest
+  :> Post '[JSON] (Response [Message])
+
+-- | Use this method to send a group of photos, videos,
+--   documents or audios as an album. Documents
+--   and audio files can be only grouped in an album
+--   with messages of the same type.
+--   On success, an array of Messages that were sent is returned.
+sendMediaGroup :: SendMediaGroupRequest ->  ClientM (Response [Message])
+sendMediaGroup = client (Proxy @SendMediaGroup)

--- a/src/Telegram/Bot/API/Methods/SendMessage.hs
+++ b/src/Telegram/Bot/API/Methods/SendMessage.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendMessage where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+import Telegram.Bot.API.Types.ParseMode
+import Telegram.Bot.API.Types.SomeReplyMarkup
+
+-- ** 'sendMessage'
+
+type SendMessage
+  = "sendMessage" :> ReqBody '[JSON] SendMessageRequest :> Post '[JSON] (Response Message)
+
+-- | Use this method to send text messages.
+-- On success, the sent 'Message' is returned.
+sendMessage :: SendMessageRequest -> ClientM (Response Message)
+sendMessage = client (Proxy @SendMessage)
+
+-- | Request parameters for 'sendMessage'.
+data SendMessageRequest = SendMessageRequest
+  { sendMessageChatId                :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername@).
+  , sendMessageMessageThreadId       :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendMessageText                  :: Text -- ^ Text of the message to be sent.
+  , sendMessageParseMode             :: Maybe ParseMode -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , sendMessageEntities              :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in message text, which can be specified instead of /parse_mode/.
+  , sendMessageDisableWebPagePreview :: Maybe Bool -- ^ Disables link previews for links in this message.
+  , sendMessageDisableNotification   :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendMessageProtectContent        :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.
+  , sendMessageReplyToMessageId      :: Maybe MessageId -- ^ If the message is a reply, ID of the original message.
+  , sendMessageAllowSendingWithoutReply :: Maybe Bool -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found.
+  , sendMessageReplyMarkup           :: Maybe SomeReplyMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  } deriving (Generic)
+
+instance ToJSON   SendMessageRequest where toJSON = gtoJSON
+instance FromJSON SendMessageRequest where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Methods/SendPhoto.hs
+++ b/src/Telegram/Bot/API/Methods/SendPhoto.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendPhoto where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (ToJSON (..))
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Bool
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Multipart.API
+import Servant.Multipart.Client
+import System.FilePath
+import Servant.Client hiding (Response)
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+import Telegram.Bot.API.Types.ParseMode
+import Telegram.Bot.API.Types.SomeReplyMarkup
+
+-- * Available methods
+
+-- ** 'sendPhoto'
+type SendPhotoContent
+  = "sendPhoto"
+  :> MultipartForm Tmp SendPhotoRequest
+  :> Post '[JSON] (Response Message)
+
+type SendPhotoLink
+  = "sendPhoto"
+  :> ReqBody '[JSON] SendPhotoRequest
+  :> Post '[JSON] (Response Message)
+
+newtype PhotoFile = MakePhotoFile InputFile
+  deriving newtype ToJSON
+
+pattern PhotoFileId :: FileId -> PhotoFile
+pattern PhotoFileId x = MakePhotoFile (InputFileId x)
+
+pattern PhotoUrl :: Text -> PhotoFile
+pattern PhotoUrl x = MakePhotoFile (FileUrl x)
+
+pattern PhotoFile :: FilePath -> ContentType -> PhotoFile
+pattern PhotoFile x y = MakePhotoFile (InputFile x y)
+
+
+-- | Request parameters for 'sendPhoto'
+data SendPhotoRequest = SendPhotoRequest
+  { sendPhotoChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @\@channelusername@).
+  , sendPhotoMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendPhotoPhoto :: PhotoFile -- ^ Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data
+  , sendPhotoThumb :: Maybe FilePath -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>
+  , sendPhotoCaption :: Maybe Text -- ^ Photo caption (may also be used when resending Photos by file_id), 0-1024 characters after entities parsing
+  , sendPhotoParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , sendPhotoCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of /parse_mode/.
+  , sendPhotoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the photo needs to be covered with a spoiler animation.
+  , sendPhotoDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendPhotoProtectContent      :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.  
+  , sendPhotoReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message.
+  , sendPhotoAllowSendingWithoutReply :: Maybe Bool -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found.
+  , sendPhotoReplyMarkup :: Maybe SomeReplyMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToMultipart Tmp SendPhotoRequest where
+  toMultipart SendPhotoRequest{..} = MultipartData fields files where
+    fields =
+      [ Input "photo" $ T.pack $ "attach://file"
+      , Input "chat_id" $ case sendPhotoChatId of
+          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
+          SomeChatUsername txt -> txt
+      ] <>
+      (   (maybe id (\t -> ((Input "message_thread_id" (T.pack $ show t)):)) sendPhotoMessageThreadId)
+        $ (maybe id (\_ -> ((Input "thumb" "attach://thumb"):)) sendPhotoThumb)
+        $ (maybe id (\t -> ((Input "caption" t):)) sendPhotoCaption)
+        $ (maybe id (\t -> ((Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)):)) sendPhotoParseMode)
+        $ (maybe id (\t -> ((Input "caption_entities" (TL.toStrict $ encodeToLazyText t)):)) sendPhotoCaptionEntities)
+        $ (maybe id (\t -> ((Input "has_spoiler" (bool "false" "true" t)):)) sendPhotoHasSpoiler)
+        $ (maybe id (\t -> ((Input "disable_notification" (bool "false" "true" t)):)) sendPhotoDisableNotification)
+        $ (maybe id (\t -> ((Input "protect_content" (bool "false" "true" t)):)) sendPhotoProtectContent)
+        $ (maybe id (\t -> ((Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)):)) sendPhotoReplyToMessageId)
+        $ (maybe id (\t -> ((Input "allow_sending_without_reply" (bool "false" "true" t)):)) sendPhotoAllowSendingWithoutReply)
+        $ (maybe id (\t -> ((Input "reply_markup" (TL.toStrict $ encodeToLazyText t)):)) sendPhotoReplyMarkup)
+        [])
+    files
+      = (FileData "file" (T.pack $ takeFileName path) ct path)
+      : maybe [] (\t -> [FileData "thumb" (T.pack $ takeFileName t) "image/jpeg" t]) sendPhotoThumb
+
+    PhotoFile path ct = sendPhotoPhoto
+
+instance ToJSON SendPhotoRequest where toJSON = gtoJSON
+
+-- | Use this method to send photos.
+-- On success, the sent 'Message' is returned.
+--
+-- <https:\/\/core.telegram.org\/bots\/api#sendphoto>
+sendPhoto :: SendPhotoRequest -> ClientM (Response Message)
+sendPhoto r = do
+  case sendPhotoPhoto r of
+    PhotoFile{} -> do
+      boundary <- liftIO genBoundary
+      client (Proxy @SendPhotoContent) (boundary, r)
+    _ -> client (Proxy @SendPhotoLink) r

--- a/src/Telegram/Bot/API/Methods/SendPoll.hs
+++ b/src/Telegram/Bot/API/Methods/SendPoll.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendPoll where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+import Telegram.Bot.API.Types.ParseMode
+
+-- ** 'sendPoll'
+
+-- | Request parameters for 'sendPoll'.
+data SendPollRequest = SendPollRequest
+  { sendPollChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendPollMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendPollQuestion :: Text -- ^ Poll question, 1-300 characters
+  , sendPollOptions :: [Text] -- ^ A JSON-serialized list of answer options, 2-10 strings 1-100 characters each
+  , sendPollIsAnonymous :: Maybe Bool -- ^ True, if the poll needs to be anonymous, defaults to True
+  , sendPollType :: Maybe Text -- ^ Poll type, “quiz” or “regular”, defaults to “regular”
+  , sendPollAllowsMultipleAnswers :: Maybe Bool -- ^ True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
+  , sendPollCorrectOptionId :: Maybe Int -- ^ 0-based identifier of the correct answer option, required for polls in quiz mode
+  , sendPollExplanation :: Maybe Text -- ^ Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line feeds after entities parsing
+  , sendPollExplanationParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , sendPollExplanationEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the poll explanation, which can be specified instead of parse_mode
+  , sendPollOpenPeriod :: Maybe Int -- ^ Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with close_date.
+  , sendPollCloseDate :: Maybe Int -- ^ Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 600 seconds in the future. Can't be used together with open_period.
+  , sendPollIsClosed :: Maybe Bool -- ^ Pass True, if the poll needs to be immediately closed. This can be useful for poll preview.
+  , sendPollDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendPollProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
+  , sendPollReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendPollAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendPollReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON   SendPollRequest where toJSON = gtoJSON
+instance FromJSON SendPollRequest where parseJSON = gparseJSON
+
+type SendPoll = "sendPoll"
+  :> ReqBody '[JSON] SendPollRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send a native poll.
+--   On success, the sent Message is returned.
+sendPoll :: SendPollRequest ->  ClientM (Response Message)
+sendPoll = client (Proxy @SendPoll)

--- a/src/Telegram/Bot/API/Methods/SendVenue.hs
+++ b/src/Telegram/Bot/API/Methods/SendVenue.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendVenue where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'sendVenue'
+
+-- | Request parameters for 'sendVenue'.
+data SendVenueRequest = SendVenueRequest
+  { sendVenueChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendVenueMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendVenueLatitude :: Float -- ^ Latitude of the venue
+  , sendVenueLongitude :: Float -- ^ Longitude of the venue
+  , sendVenueTitle :: Text -- ^ Name of the venue
+  , sendVenueAddress :: Text -- ^ Address of the venue
+  , sendVenueFoursquareId :: Maybe Text -- ^ Foursquare identifier of the venue
+  , sendVenueFoursquareType :: Maybe Text -- ^ Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+  , sendVenueGooglePlaceId :: Maybe Text -- ^ Google Places identifier of the venue
+  , sendVenueGooglePlaceType :: Maybe Text -- ^ Google Places type of the venue. (See supported types <https:\/\/developers.google.com\/maps\/documentation\/places\/web-service\/supported_types>.)
+  , sendVenueDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendVenueProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
+  , sendVenueReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendVenueAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendVenueReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON   SendVenueRequest where toJSON = gtoJSON
+instance FromJSON SendVenueRequest where parseJSON = gparseJSON
+
+type SendVenue = "sendVenue"
+  :> ReqBody '[JSON] SendVenueRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send information about a venue.
+--   On success, the sent Message is returned.
+sendVenue :: SendVenueRequest ->  ClientM (Response Message)
+sendVenue = client (Proxy @SendVenue)

--- a/src/Telegram/Bot/API/Methods/SendVideo.hs
+++ b/src/Telegram/Bot/API/Methods/SendVideo.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendVideo where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (ToJSON (..))
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Bool
+import Data.Maybe (catMaybes)
+import Data.Functor ((<&>))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Multipart.API
+import Servant.Multipart.Client
+import Servant.Client hiding (Response)
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+import Telegram.Bot.API.Types.ParseMode
+
+-- ** 'sendVideo'
+
+-- | Request parameters for 'sendVideo'.
+data SendVideoRequest = SendVideoRequest
+  { sendVideoChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , sendVideoMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendVideoVideo :: InputFile -- ^ Video to send. Pass a file_id as String to send an video that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a video from the Internet, or upload a new video using multipart/form-data. More info on Sending Files »
+  , sendVideoDuration :: Maybe Int -- ^ Duration of sent video in seconds
+  , sendVideoWidth :: Maybe Int -- ^ Video width
+  , sendVideoHeight :: Maybe Int -- ^ Video height
+  , sendVideoThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+  , sendVideoCaption :: Maybe Text -- ^ Video caption (may also be used when resending videos by file_id), 0-1024 characters after entities parsing
+  , sendVideoParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , sendVideoCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+  , sendVideoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
+  , sendVideoSupportsStreaming :: Maybe Bool -- ^ Pass True, if the uploaded video is suitable for streaming
+  , sendVideoDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendVideoProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving.
+  , sendVideoReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendVideoAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendVideoReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON SendVideoRequest where toJSON = gtoJSON
+
+instance ToMultipart Tmp SendVideoRequest where
+  toMultipart SendVideoRequest{..} =
+    maybe id (makeFile "thumb") sendVideoThumb $
+    makeFile "video" sendVideoVideo $
+    MultipartData fields [] where
+    fields =
+      [ Input "chat_id" $ case sendVideoChatId of
+          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
+          SomeChatUsername txt -> txt
+      ] <> catMaybes
+      [ sendVideoMessageThreadId <&>
+        \t -> Input "message_thread_id" (T.pack $ show t)
+      , sendVideoCaption <&>
+        \t -> Input "caption" t
+      , sendVideoParseMode <&>
+        \t -> Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)
+      , sendVideoCaptionEntities <&>
+        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
+      , sendVideoHasSpoiler <&>
+        \t -> Input "has_spoiler" (bool "false" "true" t)
+      , sendVideoDuration <&>
+        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
+      , sendVideoWidth <&>
+        \t -> Input "width" (TL.toStrict $ encodeToLazyText t)
+      , sendVideoHeight <&>
+        \t -> Input "height" (TL.toStrict $ encodeToLazyText t)
+      , sendVideoDisableNotification <&>
+        \t -> Input "disable_notification" (bool "false" "true" t)
+      , sendVideoSupportsStreaming <&>
+        \t -> Input "supports_streaming" (bool "false" "true" t)
+      , sendVideoProtectContent <&>
+        \t -> Input "protect_content" (bool "false" "true" t)
+      , sendVideoReplyToMessageId <&>
+        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
+      , sendVideoAllowSendingWithoutReply <&>
+        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
+      , sendVideoReplyMarkup <&>
+        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
+      ]
+
+type SendVideoContent
+  = "sendVideo"
+  :> MultipartForm Tmp SendVideoRequest
+  :> Post '[JSON] (Response Message)
+
+type SendVideoLink
+  = "sendVideo"
+  :> ReqBody '[JSON] SendVideoRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send video files,
+--   Telegram clients support mp4 videos
+--   (other formats may be sent as Document).
+--   On success, the sent Message is returned.
+--   Bots can currently send video files of up
+--   to 50 MB in size, this limit may be changed in the future.
+sendVideo :: SendVideoRequest ->  ClientM (Response Message)
+sendVideo r = case (sendVideoVideo r, sendVideoThumb r) of
+  (InputFile{}, _) -> do
+    boundary <- liftIO genBoundary
+    client (Proxy @SendVideoContent) (boundary, r)
+  (_, Just InputFile{}) -> do
+    boundary <- liftIO genBoundary
+    client (Proxy @SendVideoContent) (boundary, r)
+  _ ->  client (Proxy @SendVideoLink) r

--- a/src/Telegram/Bot/API/Methods/SendVideoNote.hs
+++ b/src/Telegram/Bot/API/Methods/SendVideoNote.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendVideoNote where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (ToJSON (..))
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Bool
+import Data.Maybe (catMaybes)
+import Data.Functor ((<&>))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Multipart.API
+import Servant.Multipart.Client
+import Servant.Client hiding (Response)
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'sendVideoNote'
+
+-- | Request parameters for 'sendVideoNote'.
+data SendVideoNoteRequest = SendVideoNoteRequest
+  { sendVideoNoteChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendVideoNoteMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendVideoNoteVideoNote :: InputFile -- ^ Video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended) or upload a new video using multipart/form-data. More info on Sending Files ». Sending video notes by a URL is currently unsupported
+  , sendVideoNoteDuration :: Maybe Int -- ^ Duration of sent video in seconds
+  , sendVideoNoteLength :: Maybe Int -- ^ Video width and height, i.e. diameter of the video message
+  , sendVideoNoteThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+  , sendVideoNoteDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendVideoNoteProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
+  , sendVideoNoteReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendVideoNoteAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendVideoNoteReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON SendVideoNoteRequest where toJSON = gtoJSON
+
+instance ToMultipart Tmp SendVideoNoteRequest where
+  toMultipart SendVideoNoteRequest{..} =
+    maybe id (makeFile "thumb") sendVideoNoteThumb $
+    makeFile "video_note" sendVideoNoteVideoNote $
+    MultipartData fields [] where
+    fields =
+      [ Input "chat_id" $ case sendVideoNoteChatId of
+          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
+          SomeChatUsername txt -> txt
+      ] <> catMaybes
+      [ sendVideoNoteMessageThreadId <&>
+        \t -> Input "message_thread_id" (T.pack $ show t)
+      , sendVideoNoteDisableNotification <&>
+        \t -> Input "disable_notification" (bool "false" "true" t)
+      , sendVideoNoteProtectContent <&>
+        \t -> Input "protect_content" (bool "false" "true" t)
+      , sendVideoNoteReplyToMessageId <&>
+        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
+      , sendVideoNoteAllowSendingWithoutReply <&>
+        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
+      , sendVideoNoteReplyMarkup <&>
+        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
+      ]
+
+type SendVideoNoteContent
+  = "sendVideoNote"
+  :> MultipartForm Tmp SendVideoNoteRequest
+  :> Post '[JSON] (Response Message)
+
+type SendVideoNoteLink
+  = "sendVideoNote"
+  :> ReqBody '[JSON] SendVideoNoteRequest
+  :> Post '[JSON] (Response Message)
+
+-- | As of v.4.0, Telegram clients support rounded
+--   square mp4 videos of up to 1 minute long. Use
+--   this method to send video messages.
+--   On success, the sent Message is returned.
+sendVideoNote :: SendVideoNoteRequest ->  ClientM (Response Message)
+sendVideoNote r = case (sendVideoNoteVideoNote r, sendVideoNoteThumb r) of
+  (InputFile{}, _) -> do
+    boundary <- liftIO genBoundary
+    client (Proxy @SendVideoNoteContent) (boundary, r)
+  (_, Just InputFile{}) -> do
+    boundary <- liftIO genBoundary
+    client (Proxy @SendVideoNoteContent) (boundary, r)
+  _ ->  client (Proxy @SendVideoNoteLink) r

--- a/src/Telegram/Bot/API/Methods/SendVoice.hs
+++ b/src/Telegram/Bot/API/Methods/SendVoice.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SendVoice where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (ToJSON (..))
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Bool
+import Data.Maybe (catMaybes)
+import Data.Functor ((<&>))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Multipart.API
+import Servant.Multipart.Client
+import Servant.Client hiding (Response)
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+import Telegram.Bot.API.Types.ParseMode
+
+-- ** 'sendVoice'
+
+-- | Request parameters for 'sendVoice'.
+data SendVoiceRequest = SendVoiceRequest
+  { sendVoiceChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendVoiceMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendVoiceVoice :: InputFile -- ^ Audio file to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More info on Sending Files »
+  , sendVoiceCaption :: Maybe Text -- ^ Voice message caption, 0-1024 characters after entities parsing
+  , sendVoiceParseMode :: Maybe ParseMode  -- ^ Send 'MarkdownV2', 'HTML' or 'Markdown' (legacy), if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+  , sendVoiceCaptionEntities :: Maybe [MessageEntity] -- ^ A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+  , sendVoiceDuration :: Maybe Int -- ^ Duration of the voice message in seconds
+  , sendVoiceDisableNotification :: Maybe Bool -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendVoiceProtectContent :: Maybe Bool -- ^ Protects the contents of the sent message from forwarding and saving
+  , sendVoiceReplyToMessageId :: Maybe MessageId -- ^ If the message is a reply, ID of the original message
+  , sendVoiceAllowSendingWithoutReply :: Maybe Bool -- ^ Pass True, if the message should be sent even if the specified replied-to message is not found
+  , sendVoiceReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON SendVoiceRequest where toJSON = gtoJSON
+
+instance ToMultipart Tmp SendVoiceRequest where
+  toMultipart SendVoiceRequest{..} =
+    makeFile "voice" sendVoiceVoice $
+    MultipartData fields [] where
+    fields =
+      [ Input "chat_id" $ case sendVoiceChatId of
+          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
+          SomeChatUsername txt -> txt
+      ] <> catMaybes
+      [ sendVoiceMessageThreadId <&>
+        \t -> Input "message_thread_id" (T.pack $ show t)
+      , sendVoiceCaption <&>
+        \t -> Input "caption" t
+      , sendVoiceParseMode <&>
+        \t -> Input "parse_mode" (TL.toStrict . TL.replace "\"" "" $ encodeToLazyText t)
+      , sendVoiceCaptionEntities <&>
+        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
+      , sendVoiceDuration <&>
+        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
+      , sendVoiceProtectContent <&>
+        \t -> Input "protect_content" (bool "false" "true" t)
+      , sendVoiceDisableNotification <&>
+        \t -> Input "disable_notification" (bool "false" "true" t)
+      , sendVoiceReplyToMessageId <&>
+        \t -> Input "reply_to_message_id" (TL.toStrict $ encodeToLazyText t)
+      , sendVoiceAllowSendingWithoutReply <&>
+        \t -> Input "allow_sending_without_reply" (bool "false" "true" t)
+      , sendVoiceReplyMarkup <&>
+        \t -> Input "reply_markup" (TL.toStrict $ encodeToLazyText t)
+      ]
+
+type SendVoiceContent
+  = "sendVoice"
+  :> MultipartForm Tmp SendVoiceRequest
+  :> Post '[JSON] (Response Message)
+
+type SendVoiceLink
+  = "sendVoice"
+  :> ReqBody '[JSON] SendVoiceRequest
+  :> Post '[JSON] (Response Message)
+
+-- | Use this method to send audio files,
+--   if you want Telegram clients to display
+--   the file as a playable voice message. For
+--   this to work, your audio must be in an .OGG
+--   file encoded with OPUS (other formats may be
+--   sent as Audio or Document).
+--   On success, the sent Message is returned.
+--   Bots can currently send voice messages of up
+--   to 50 MB in size, this limit may be changed in the future.
+sendVoice :: SendVoiceRequest ->  ClientM (Response Message)
+sendVoice r = case sendVoiceVoice r of
+  InputFile{} -> do
+    boundary <- liftIO genBoundary
+    client (Proxy @SendVoiceContent) (boundary, r)
+  _ ->  client (Proxy @SendVoiceLink) r

--- a/src/Telegram/Bot/API/Methods/SetChatAdministratorCustomTitle.hs
+++ b/src/Telegram/Bot/API/Methods/SetChatAdministratorCustomTitle.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SetChatAdministratorCustomTitle where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'setChatAdministratorCustomTitle'
+
+-- | Request parameters for 'setChatAdministratorCustomTitle'.
+data SetChatAdministratorCustomTitleRequest = SetChatAdministratorCustomTitleRequest
+  { setChatAdministratorCustomTitleChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , setChatAdministratorCustomTitleUserId :: UserId -- ^ Unique identifier of the target user
+  , setChatAdministratorCustomTitleCustomTitle :: Text -- ^ New custom title for the administrator; 0-16 characters, emoji are not allowed
+  }
+  deriving Generic
+
+instance ToJSON   SetChatAdministratorCustomTitleRequest where toJSON = gtoJSON
+instance FromJSON SetChatAdministratorCustomTitleRequest where parseJSON = gparseJSON
+
+type SetChatAdministratorCustomTitle = "setChatAdministratorCustomTitle"
+  :> ReqBody '[JSON] SetChatAdministratorCustomTitleRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to set a custom title
+--   for an administrator in a supergroup
+--   promoted by the bot.
+--   Returns True on success.
+setChatAdministratorCustomTitle :: SetChatAdministratorCustomTitleRequest ->  ClientM (Response Bool)
+setChatAdministratorCustomTitle = client (Proxy @SetChatAdministratorCustomTitle)

--- a/src/Telegram/Bot/API/Methods/SetChatDescription.hs
+++ b/src/Telegram/Bot/API/Methods/SetChatDescription.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SetChatDescription where
+
+import Data.Proxy
+import Data.Text (Text)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'setChatDescription'
+
+type SetChatDescription = "setChatDescription"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> QueryParam "description" Text
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to change the description 
+--   of a group, a supergroup or a channel. The 
+--   bot must be an administrator in the chat 
+--   for this to work and must have the appropriate 
+--   administrator rights. 
+--   Returns True on success.
+setChatDescription :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> Maybe Text -- ^ New chat description, 0-255 characters
+  -> ClientM (Response Bool)
+setChatDescription = client (Proxy @SetChatDescription)

--- a/src/Telegram/Bot/API/Methods/SetChatMenuButton.hs
+++ b/src/Telegram/Bot/API/Methods/SetChatMenuButton.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SetChatMenuButton where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'setChatMenuButton'
+
+-- | Request parameters for 'setChatMenuButton'.
+data SetChatMenuButtonRequest = SetChatMenuButtonRequest
+  { setChatMenuButtonRequestChatId     :: Maybe ChatId     -- ^ Unique identifier for the target private chat. If not specified, default bot's menu button will be changed.
+  , setChatMenuButtonRequestMenuButton :: Maybe MenuButton -- ^ A JSON-serialized object for the new bot's menu button. Defaults to @MenuButtonDefault@.
+  }
+  deriving Generic
+
+instance ToJSON   SetChatMenuButtonRequest where toJSON = gtoJSON
+instance FromJSON SetChatMenuButtonRequest where parseJSON = gparseJSON
+
+type SetChatMenuButton = "setChatMenuButton"
+  :> ReqBody '[JSON] SetChatMenuButtonRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to change the bot's menu button in a private chat,
+--  or the default menu button. Returns True on success.
+setChatMenuButton :: SetChatMenuButtonRequest -> ClientM (Response Bool)
+setChatMenuButton = client (Proxy @SetChatMenuButton)

--- a/src/Telegram/Bot/API/Methods/SetChatPermissions.hs
+++ b/src/Telegram/Bot/API/Methods/SetChatPermissions.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SetChatPermissions where
+
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'setChatPermissions'
+
+-- | Request parameters for 'setChatPermissions'.
+data SetChatPermissionsRequest = SetChatPermissionsRequest
+  { setChatPermissionsChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , setChatPermissionsPermissions :: ChatPermissions -- ^ A JSON-serialized object for new default chat permissions.
+  , setChatPermissionsUseIndependentChatPermissions :: Maybe Bool -- ^ Pass 'True' if chat permissions are set independently. Otherwise, the @can_send_other_messages@ and @can_add_web_page_previews@ permissions will imply the @can_send_messages@, @can_send_audios@, @can_send_documents@, @can_send_photos@, @can_send_videos@, @can_send_video_notes@, and @can_send_voice_notes@ permissions; the @can_send_polls@ permission will imply the @can_send_messages@ permission.
+  }
+  deriving Generic
+
+instance ToJSON   SetChatPermissionsRequest where toJSON = gtoJSON
+instance FromJSON SetChatPermissionsRequest where parseJSON = gparseJSON
+
+type SetChatPermissions = "setChatPermissions"
+  :> ReqBody '[JSON] SetChatPermissionsRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to set default chat
+--   permissions for all members. The bot
+--   must be an administrator in the group
+--   or a supergroup for this to work and must
+--   have the can_restrict_members administrator rights.
+--   Returns True on success.
+setChatPermissions :: SetChatPermissionsRequest ->  ClientM (Response Bool)
+setChatPermissions = client (Proxy @SetChatPermissions)

--- a/src/Telegram/Bot/API/Methods/SetChatPhoto.hs
+++ b/src/Telegram/Bot/API/Methods/SetChatPhoto.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SetChatPhoto where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Proxy
+import Servant.API
+import Servant.Multipart.API
+import Servant.Multipart.Client
+import Servant.Client hiding (Response)
+
+import qualified Data.Text as T
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'setChatPhoto'
+
+-- | Request parameters for 'setChatPhoto'.
+data SetChatPhotoRequest = SetChatPhotoRequest
+  { setChatPhotoChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , setChatPhotoPhoto :: InputFile -- ^ 	New chat photo, uploaded using multipart/form-data
+  }
+
+instance ToMultipart Tmp SetChatPhotoRequest where
+  toMultipart SetChatPhotoRequest{..} =
+    makeFile "photo" setChatPhotoPhoto (MultipartData fields []) where
+    fields =
+      [ Input "chat_id" $ case setChatPhotoChatId of
+          SomeChatId (ChatId chat_id) -> T.pack $ show chat_id
+          SomeChatUsername txt -> txt
+      ]
+
+type SetChatPhoto = "setChatPhoto"
+  :> MultipartForm Tmp SetChatPhotoRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to set a new profile 
+--   photo for the chat. Photos can't be changed
+--   for private chats. The bot must be an 
+--   administrator in the chat for this to work 
+--   and must have the appropriate administrator rights. 
+--   Returns True on success.
+--
+-- *Note*: Only 'InputFile' case might be used in 'SetChatPhotoRequest'.
+-- Rest cases will be rejected by Telegram.
+setChatPhoto :: SetChatPhotoRequest ->  ClientM (Response Bool)
+setChatPhoto r =do
+      boundary <- liftIO genBoundary
+      client (Proxy @SetChatPhoto) (boundary, r)

--- a/src/Telegram/Bot/API/Methods/SetChatStickerSet.hs
+++ b/src/Telegram/Bot/API/Methods/SetChatStickerSet.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SetChatStickerSet where
+
+import Data.Proxy
+import Data.Text
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'setChatStickerSet'
+
+type SetChatStickerSet = "setChatStickerSet"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> RequiredQueryParam "sticker_set_name" Text
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to set a new group sticker
+--   set for a supergroup. The bot must be an 
+--   administrator in the chat for this to work 
+--   and must have the appropriate administrator 
+--   rights. Use the field can_set_sticker_set 
+--   optionally returned in getChat requests to 
+--   check if the bot can use this method. 
+--   Returns True on success.
+setChatStickerSet :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> Text -- ^ 	Name of the sticker set to be set as the group sticker set
+  -> ClientM (Response Bool)
+setChatStickerSet = client (Proxy @SetChatStickerSet)

--- a/src/Telegram/Bot/API/Methods/SetChatTitle.hs
+++ b/src/Telegram/Bot/API/Methods/SetChatTitle.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SetChatTitle where
+
+import Data.Proxy
+import Data.Text (Text)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'setChatTitle'
+
+type SetChatTitle = "setChatTitle"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> RequiredQueryParam "title" Text
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to change the title of
+--   a chat. Titles can't be changed for private
+--   chats. The bot must be an administrator in 
+--   the chat for this to work and must have the 
+--   appropriate administrator rights. 
+--   Returns True on success.
+setChatTitle :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> Text -- ^ New chat title, 0-255 characters
+  -> ClientM (Response Bool)
+setChatTitle = client (Proxy @SetChatTitle)

--- a/src/Telegram/Bot/API/Methods/SetMyCommands.hs
+++ b/src/Telegram/Bot/API/Methods/SetMyCommands.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SetMyCommands where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'setMyCommands'
+
+-- | Request parameters for 'setMyCommands'.
+data SetMyCommandsRequest = SetMyCommandsRequest
+  { setMyCommandsCommands :: [BotCommand] -- ^ A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
+  , setMyCommandsScope :: Maybe BotCommandScope -- ^ A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
+  , setMyCommandsLanguageCode :: Maybe Text -- ^ A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
+  }
+  deriving Generic
+
+instance ToJSON   SetMyCommandsRequest where toJSON = gtoJSON
+instance FromJSON SetMyCommandsRequest where parseJSON = gparseJSON
+
+type SetMyCommands = "setMyCommands"
+  :> ReqBody '[JSON] SetMyCommandsRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to change the list of 
+--   the bot's commands. See <https:\/\/core.telegram.org\/bots#commands> 
+--   for more details about bot commands. 
+--   Returns True on success.
+setMyCommands :: SetMyCommandsRequest ->  ClientM (Response Bool)
+setMyCommands = client (Proxy @SetMyCommands)

--- a/src/Telegram/Bot/API/Methods/SetMyDefaultAdministratorRights.hs
+++ b/src/Telegram/Bot/API/Methods/SetMyDefaultAdministratorRights.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.SetMyDefaultAdministratorRights where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'setMyDefaultAdministratorRights'
+
+-- | Request parameters for 'setMyDefaultAdministratorRights'.
+data SetMyDefaultAdministratorRightsRequest = SetMyDefaultAdministratorRightsRequest
+  { setMyDefaultAdministratorRightsRequestRights      :: Maybe ChatAdministratorRights -- ^ A JSON-serialized object describing new default administrator rights. If not specified, the default administrator rights will be cleared.
+  , setMyDefaultAdministratorRightsRequestForChannels :: Maybe Bool -- ^ Pass 'True' to change the default administrator rights of the bot in channels. Otherwise, the default administrator rights of the bot for groups and supergroups will be changed.
+  }
+  deriving Generic
+
+instance ToJSON   SetMyDefaultAdministratorRightsRequest where toJSON = gtoJSON
+instance FromJSON SetMyDefaultAdministratorRightsRequest where parseJSON = gparseJSON
+
+type SetMyDefaultAdministratorRights = "setMyDefaultAdministratorRights"
+  :> ReqBody '[JSON] SetMyDefaultAdministratorRightsRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to change the default administrator rights requested by the bot when it's added as an administrator to groups or channels. These rights will be suggested to users, but they are are free to modify the list before adding the bot. Returns 'True' on success.
+setMyDefaultAdministratorRights
+  :: SetMyDefaultAdministratorRightsRequest -> ClientM (Response Bool)
+setMyDefaultAdministratorRights = client (Proxy @SetMyDefaultAdministratorRights)

--- a/src/Telegram/Bot/API/Methods/StopMessageLiveLocation.hs
+++ b/src/Telegram/Bot/API/Methods/StopMessageLiveLocation.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.StopMessageLiveLocation where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import Data.Text
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'stopMessageLiveLocation'
+
+-- | Request parameters for 'stopMessageLiveLocation'.
+data StopMessageLiveLocationRequest = StopMessageLiveLocationRequest
+  { stopMessageLiveLocationChatId :: Maybe SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , stopMessageLiveLocationMessageId :: Maybe MessageId -- ^ Required if inline_message_id is not specified. Identifier of the message with live location to stop
+  , stopMessageLiveLocationInlineMessageId :: Maybe Text -- ^  	Required if chat_id and message_id are not specified. Identifier of the inline message
+  , stopMessageLiveLocationReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+  }
+  deriving Generic
+
+instance ToJSON   StopMessageLiveLocationRequest where toJSON = gtoJSON
+instance FromJSON StopMessageLiveLocationRequest where parseJSON = gparseJSON
+
+type StopMessageLiveLocation = "stopMessageLiveLocation"
+  :> ReqBody '[JSON] StopMessageLiveLocationRequest
+  :> Post '[JSON] (Response (Either Bool Message))
+
+-- | Use this method to stop updating a live
+--   location message before live_period
+--   expires. On success, if the message is
+--   not an inline message, the edited Message
+--   is returned, otherwise True is returned.
+stopMessageLiveLocation :: StopMessageLiveLocationRequest ->  ClientM (Response (Either Bool Message))
+stopMessageLiveLocation = client (Proxy @StopMessageLiveLocation)

--- a/src/Telegram/Bot/API/Methods/UnbanChatMember.hs
+++ b/src/Telegram/Bot/API/Methods/UnbanChatMember.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.UnbanChatMember where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- | Request parameters for 'unbanChatMember'.
+data UnbanChatMemberRequest = UnbanChatMemberRequest
+  { unbanChatMemberChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+  , unbanChatMemberUserId :: UserId -- ^ Unique identifier of the target user
+  , unbanChatMemberOnlyIfBanned :: Maybe Bool -- ^ Do nothing if the user is not banned
+  }
+  deriving Generic
+
+instance ToJSON   UnbanChatMemberRequest where toJSON = gtoJSON
+instance FromJSON UnbanChatMemberRequest where parseJSON = gparseJSON
+
+type UnbanChatMember = "unbanChatMember"
+  :> ReqBody '[JSON] UnbanChatMemberRequest
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to unban a previously
+--   banned user in a supergroup or channel.
+--   The user will not return to the group
+--   or channel automatically, but will be
+--   able to join via link, etc. The bot must
+--   be an administrator for this to work. By
+--   default, this method guarantees that after
+--   the call the user is not a member of the chat,
+--   but will be able to join it. So if the user is
+--   a member of the chat they will also be removed
+--   from the chat. If you don't want this, use the
+--   parameter only_if_banned.
+--   Returns True on success.
+unbanChatMember :: UnbanChatMemberRequest ->  ClientM (Response Bool)
+unbanChatMember = client (Proxy @UnbanChatMember)

--- a/src/Telegram/Bot/API/Methods/UnbanChatSenderChat.hs
+++ b/src/Telegram/Bot/API/Methods/UnbanChatSenderChat.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.UnbanChatSenderChat where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'unbanChatSenderChat'
+
+type UnbanChatSenderChat = "unbanChatSenderChat"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> RequiredQueryParam "sender_chat_id" ChatId
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to unban a previously
+--   banned channel chat in a supergroup
+--   or channel. The bot must be an administrator
+--   for this to work and must have the appropriate
+--   administrator rights.
+--   Returns True on success.
+unbanChatSenderChat :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ChatId -- ^ Unique identifier of the target sender chat
+  -> ClientM (Response  Bool)
+unbanChatSenderChat = client (Proxy @UnbanChatSenderChat)

--- a/src/Telegram/Bot/API/Methods/UnpinAllChatMessages.hs
+++ b/src/Telegram/Bot/API/Methods/UnpinAllChatMessages.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.UnpinAllChatMessages where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'unpinAllChatMessages'
+
+type UnpinAllChatMessages = "unpinAllChatMessages"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to clear the list of pinned 
+--   messages in a chat. If the chat is not a private 
+--   chat, the bot must be an administrator in the 
+--   chat for this to work and must have the 'can_pin_messages' 
+--   administrator right in a supergroup or 'can_edit_messages' 
+--   administrator right in a channel. 
+--   Returns True on success.
+unpinAllChatMessages :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> ClientM (Response Bool)
+unpinAllChatMessages = client (Proxy @UnpinAllChatMessages)

--- a/src/Telegram/Bot/API/Methods/UnpinChatMessage.hs
+++ b/src/Telegram/Bot/API/Methods/UnpinChatMessage.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+module Telegram.Bot.API.Methods.UnpinChatMessage where
+
+import Data.Proxy
+import Servant.API
+import Servant.Client hiding (Response)
+
+import Telegram.Bot.API.MakingRequests
+import Telegram.Bot.API.Types
+
+-- ** 'unpinChatMessage'
+
+type UnpinChatMessage = "unpinChatMessage"
+  :> RequiredQueryParam "chat_id" SomeChatId
+  :> QueryParam "message_id" MessageId
+  :> Post '[JSON] (Response Bool)
+
+-- | Use this method to remove a message from the
+--   list of pinned messages in a chat. If the chat 
+--   is not a private chat, the bot must be an administrator
+--   in the chat for this to work and must have the 
+--   'can_pin_messages' administrator right in a supergroup 
+--   or 'can_edit_messages' administrator right in a 
+--   channel. 
+--   Returns True on success.
+unpinChatMessage :: SomeChatId -- ^ Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+  -> Maybe MessageId -- ^ Identifier of a message to unpin. If not specified, the most recent pinned message (by sending date) will be unpinned.
+  -> ClientM (Response Bool)
+unpinChatMessage = client (Proxy @UnpinChatMessage)

--- a/src/Telegram/Bot/API/Payments.hs
+++ b/src/Telegram/Bot/API/Payments.hs
@@ -20,34 +20,34 @@ import Telegram.Bot.API.MakingRequests
 -- ** 'sendInvoice'
 
 data SendInvoiceRequest = SendInvoiceRequest
-  { sendInvoiceRequestChatId                    :: ChatId                     -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , sendInvoiceRequestMessageThreadId           :: Maybe MessageThreadId      -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
-  , sendInvoiceRequestTitle                     :: Text                       -- ^ Product name, 1-32 characters.
-  , sendInvoiceRequestDescription               :: Text                       -- ^ Product description, 1-255 characters.
-  , sendInvoiceRequestPayload                   :: Text                       -- ^ Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
-  , sendInvoiceRequestProviderToken             :: Text                       -- ^ Payments provider token, obtained via Botfather.
-  , sendInvoiceRequestCurrency                  :: Text                       -- ^ Three-letter ISO 4217 currency code, see more on currencies.
-  , sendInvoiceRequestPrices                    :: [LabeledPrice]             -- ^ Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.).
-  , sendInvoiceRequestMaxTipAmount              :: Maybe Integer              -- ^ The maximum accepted amount for tips in the smallest units of the currency (integer, not float\/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0.
-  , sendInvoiceRequestSuggestedTipAmounts       :: Maybe [Integer]            -- ^ A JSON-serialized array of suggested amounts of tips in the smallest units of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.
-  , sendInvoiceRequestStartParameter            :: Maybe Text                 -- ^ Unique deep-linking parameter. If left empty, forwarded copies of the sent message will have a Pay button, allowing multiple users to pay directly from the forwarded message, using the same invoice. If non-empty, forwarded copies of the sent message will have a URL button with a deep link to the bot (instead of a Pay button), with the value used as the start parameter.
-  , sendInvoiceRequestProviderData              :: Maybe Text                 -- ^ A JSON-serialized data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.
-  , sendInvoiceRequestPhotoUrl                  :: Maybe Text                 -- ^ URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service. People like it better when they see what they are paying for.
-  , sendInvoiceRequestPhotoSize                 :: Maybe Int                  -- ^ Photo size.
-  , sendInvoiceRequestPhotoWidth                :: Maybe Int                  -- ^ Photo width.
-  , sendInvoiceRequestPhotoHeight               :: Maybe Int                  -- ^ Photo height.
-  , sendInvoiceRequestNeedName                  :: Maybe Bool                 -- ^ Pass 'True', if you require the user's full name to complete the order.
-  , sendInvoiceRequestNeedPhoneNumber           :: Maybe Bool                 -- ^ Pass 'True', if you require the user's phone number to complete the order.
-  , sendInvoiceRequestNeedEmail                 :: Maybe Bool                 -- ^ Pass 'True', if you require the user's email address to complete the order.
-  , sendInvoiceRequestNeedShippingAddress       :: Maybe Bool                 -- ^ Pass 'True', if you require the user's shipping address to complete the order.
-  , sendInvoiceRequestSendPhoneNumberToProvider :: Maybe Bool                 -- ^ Pass 'True', if you require the user's phone number to complete the order.
-  , sendInvoiceRequestSendEmailToProvider       :: Maybe Bool                 -- ^ Pass 'True', if user's email address should be sent to provider.
-  , sendInvoiceRequestIsFlexible                :: Maybe Bool                 -- ^ Pass 'True', if the final price depends on the shipping method.
-  , sendInvoiceRequestDisableNotification       :: Maybe Bool                 -- ^ Sends the message silently. Users will receive a notification with no sound.
-  , sendInvoiceRequestProtectContent            :: Maybe Bool                 -- ^ Protects the contents of the sent message from forwarding and saving.
-  , sendInvoiceRequestReplyToMessageId          :: Maybe MessageId            -- ^ If the message is a reply, ID of the original message.
-  , sendInvoiceRequestAllowSendingWithoutReply  :: Maybe Bool                 -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found.
-  , sendInvoiceRequestReplyMarkup               :: Maybe InlineKeyboardMarkup -- ^ A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
+  { sendInvoiceChatId                    :: ChatId                     -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+  , sendInvoiceMessageThreadId           :: Maybe MessageThreadId      -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , sendInvoiceTitle                     :: Text                       -- ^ Product name, 1-32 characters.
+  , sendInvoiceDescription               :: Text                       -- ^ Product description, 1-255 characters.
+  , sendInvoicePayload                   :: Text                       -- ^ Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
+  , sendInvoiceProviderToken             :: Text                       -- ^ Payments provider token, obtained via Botfather.
+  , sendInvoiceCurrency                  :: Text                       -- ^ Three-letter ISO 4217 currency code, see more on currencies.
+  , sendInvoicePrices                    :: [LabeledPrice]             -- ^ Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.).
+  , sendInvoiceMaxTipAmount              :: Maybe Integer              -- ^ The maximum accepted amount for tips in the smallest units of the currency (integer, not float\/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0.
+  , sendInvoiceequestSuggestedTipAmounts       :: Maybe [Integer]            -- ^ A JSON-serialized array of suggested amounts of tips in the smallest units of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.
+  , sendInvoiceStartParameter            :: Maybe Text                 -- ^ Unique deep-linking parameter. If left empty, forwarded copies of the sent message will have a Pay button, allowing multiple users to pay directly from the forwarded message, using the same invoice. If non-empty, forwarded copies of the sent message will have a URL button with a deep link to the bot (instead of a Pay button), with the value used as the start parameter.
+  , sendInvoiceProviderData              :: Maybe Text                 -- ^ A JSON-serialized data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.
+  , sendInvoicePhotoUrl                  :: Maybe Text                 -- ^ URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service. People like it better when they see what they are paying for.
+  , sendInvoicePhotoSize                 :: Maybe Int                  -- ^ Photo size.
+  , sendInvoicePhotoWidth                :: Maybe Int                  -- ^ Photo width.
+  , sendInvoicePhotoHeight               :: Maybe Int                  -- ^ Photo height.
+  , sendInvoiceNeedName                  :: Maybe Bool                 -- ^ Pass 'True', if you require the user's full name to complete the order.
+  , sendInvoiceNeedPhoneNumber           :: Maybe Bool                 -- ^ Pass 'True', if you require the user's phone number to complete the order.
+  , sendInvoiceNeedEmail                 :: Maybe Bool                 -- ^ Pass 'True', if you require the user's email address to complete the order.
+  , sendInvoiceNeedShippingAddress       :: Maybe Bool                 -- ^ Pass 'True', if you require the user's shipping address to complete the order.
+  , sendInvoiceSendPhoneNumberToProvider :: Maybe Bool                 -- ^ Pass 'True', if you require the user's phone number to complete the order.
+  , sendInvoiceSendEmailToProvider       :: Maybe Bool                 -- ^ Pass 'True', if user's email address should be sent to provider.
+  , sendInvoiceIsFlexible                :: Maybe Bool                 -- ^ Pass 'True', if the final price depends on the shipping method.
+  , sendInvoiceDisableNotification       :: Maybe Bool                 -- ^ Sends the message silently. Users will receive a notification with no sound.
+  , sendInvoiceProtectContent            :: Maybe Bool                 -- ^ Protects the contents of the sent message from forwarding and saving.
+  , sendInvoiceReplyToMessageId          :: Maybe MessageId            -- ^ If the message is a reply, ID of the original message.
+  , sendInvoiceAllowSendingWithoutReply  :: Maybe Bool                 -- ^ Pass 'True', if the message should be sent even if the specified replied-to message is not found.
+  , sendInvoiceReplyMarkup               :: Maybe InlineKeyboardMarkup -- ^ A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
   }
   deriving (Generic, Show)
 
@@ -66,26 +66,26 @@ sendInvoice = client (Proxy @SendInvoice)
 -- ** 'createInvoiceLink'
 
 data CreateInvoiceLinkRequest = CreateInvoiceLinkRequest
-  { createInvoiceLinkRequestTitle                     :: Text            -- ^ Product name, 1-32 characters.
-  , createInvoiceLinkRequestDescription               :: Text            -- ^ Product description, 1-255 characters.
-  , createInvoiceLinkRequestPayload                   :: Text            -- ^ Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
-  , createInvoiceLinkRequestProviderToken             :: Text            -- ^ Payment provider token, obtained via BotFather.
-  , createInvoiceLinkRequestCurrency                  :: Text            -- ^ Three-letter ISO 4217 currency code, see more on currencies.
-  , createInvoiceLinkRequestPrices                    :: [LabeledPrice]  -- ^ Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.).
-  , createInvoiceLinkRequestMaxTipAmount              :: Maybe Integer   -- ^ The maximum accepted amount for tips in the smallest units of the currency (integer, not float\/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0.
-  , createInvoiceLinkRequestSuggestedTipAmounts       :: Maybe [Integer] -- ^ A JSON-serialized array of suggested amounts of tips in the smallest units of the currency (integer, not float\/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed @max_tip_amount@.
-  , createInvoiceLinkRequestProviderData              :: Maybe Text      -- ^ JSON-serialized data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.
-  , createInvoiceLinkRequestPhotoUrl                  :: Maybe Text      -- ^ URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service.
-  , createInvoiceLinkRequestPhotoSize                 :: Maybe Int       -- ^ Photo size in bytes.
-  , createInvoiceLinkRequestPhotoWidth                :: Maybe Int       -- ^ Photo width.
-  , createInvoiceLinkRequestPhotoHeight               :: Maybe Int       -- ^ Photo height
-  , createInvoiceLinkRequestNeedName                  :: Maybe Bool      -- ^ Pass 'True' if you require the user's full name to complete the order.
-  , createInvoiceLinkRequestNeedPhoneNumber           :: Maybe Bool      -- ^ Pass 'True' if you require the user's phone number to complete the order.
-  , createInvoiceLinkRequestNeedEmail                 :: Maybe Bool      -- ^ Pass 'True' if you require the user's email address to complete the order.
-  , createInvoiceLinkRequestNeedShippingAddress       :: Maybe Bool      -- ^ Pass 'True' if you require the user's shipping address to complete the order.
-  , createInvoiceLinkRequestSendPhoneNumberToProvider :: Maybe Bool      -- ^ Pass 'True' if the user's phone number should be sent to the provider.
-  , createInvoiceLinkRequestSendEmailToProvider       :: Maybe Bool      -- ^ Pass 'True' if the user's email address should be sent to the provider.
-  , createInvoiceLinkRequestIsFlexible                :: Maybe Bool      -- ^ Pass 'True' if the final price depends on the shipping method.
+  { createInvoiceLinkTitle                     :: Text            -- ^ Product name, 1-32 characters.
+  , createInvoiceLinkDescription               :: Text            -- ^ Product description, 1-255 characters.
+  , createInvoiceLinkPayload                   :: Text            -- ^ Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
+  , createInvoiceLinkProviderToken             :: Text            -- ^ Payment provider token, obtained via BotFather.
+  , createInvoiceLinkCurrency                  :: Text            -- ^ Three-letter ISO 4217 currency code, see more on currencies.
+  , createInvoiceLinkPrices                    :: [LabeledPrice]  -- ^ Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.).
+  , createInvoiceLinkMaxTipAmount              :: Maybe Integer   -- ^ The maximum accepted amount for tips in the smallest units of the currency (integer, not float\/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0.
+  , createInvoiceLinkSuggestedTipAmounts       :: Maybe [Integer] -- ^ A JSON-serialized array of suggested amounts of tips in the smallest units of the currency (integer, not float\/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed @max_tip_amount@.
+  , createInvoiceLinkProviderData              :: Maybe Text      -- ^ JSON-serialized data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.
+  , createInvoiceLinkPhotoUrl                  :: Maybe Text      -- ^ URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service.
+  , createInvoiceLinkPhotoSize                 :: Maybe Int       -- ^ Photo size in bytes.
+  , createInvoiceLinkPhotoWidth                :: Maybe Int       -- ^ Photo width.
+  , createInvoiceLinkPhotoHeight               :: Maybe Int       -- ^ Photo height
+  , createInvoiceLinkNeedName                  :: Maybe Bool      -- ^ Pass 'True' if you require the user's full name to complete the order.
+  , createInvoiceLinkNeedPhoneNumber           :: Maybe Bool      -- ^ Pass 'True' if you require the user's phone number to complete the order.
+  , createInvoiceLinkNeedEmail                 :: Maybe Bool      -- ^ Pass 'True' if you require the user's email address to complete the order.
+  , createInvoiceLinkNeedShippingAddress       :: Maybe Bool      -- ^ Pass 'True' if you require the user's shipping address to complete the order.
+  , createInvoiceLinkSendPhoneNumberToProvider :: Maybe Bool      -- ^ Pass 'True' if the user's phone number should be sent to the provider.
+  , createInvoiceLinkSendEmailToProvider       :: Maybe Bool      -- ^ Pass 'True' if the user's email address should be sent to the provider.
+  , createInvoiceLinkIsFlexible                :: Maybe Bool      -- ^ Pass 'True' if the final price depends on the shipping method.
   }
   deriving (Generic, Show)
 
@@ -104,10 +104,10 @@ createInvoiceLink = client (Proxy @CreateInvoiceLink)
 -- ** 'answerShippingQuery'
 
 data AnswerShippingQueryRequest = AnswerShippingQueryRequest
-  { answerShippingQueryRequestShippingQueryId :: Text                   -- ^ Unique identifier for the query to be answered.
-  , answerShippingQueryRequestOk              :: Bool                   -- ^ Specify 'True' if delivery to the specified address is possible and 'False' if there are any problems (for example, if delivery to the specified address is not possible).
-  , answerShippingQueryRequestShippingOptions :: Maybe [ShippingOption] -- ^ Required if @ok@ is 'True'. A JSON-serialized array of available shipping options.
-  , answerShippingQueryRequestErrorMessage    :: Maybe Text             -- ^ Required if @ok@ is 'False'. Error message in human readable form that explains why it is impossible to complete the order (e.g. "Sorry, delivery to your desired address is unavailable'). Telegram will display this message to the user.
+  { answerShippingQueryShippingQueryId :: Text                   -- ^ Unique identifier for the query to be answered.
+  , answerShippingQueryOk              :: Bool                   -- ^ Specify 'True' if delivery to the specified address is possible and 'False' if there are any problems (for example, if delivery to the specified address is not possible).
+  , answerShippingQueryShippingOptions :: Maybe [ShippingOption] -- ^ Required if @ok@ is 'True'. A JSON-serialized array of available shipping options.
+  , answerShippingQueryErrorMessage    :: Maybe Text             -- ^ Required if @ok@ is 'False'. Error message in human readable form that explains why it is impossible to complete the order (e.g. "Sorry, delivery to your desired address is unavailable'). Telegram will display this message to the user.
   }
   deriving (Generic, Show)
 
@@ -126,9 +126,9 @@ answerShippingQuery = client (Proxy @AnswerShippingQuery)
 -- ** 'answerPreCheckoutQuery'
 
 data AnswerPreCheckoutQueryRequest = AnswerPreCheckoutQueryRequest
-  { answerPreCheckoutQueryRequestPreCheckoutQueryId :: Text       -- ^ Unique identifier for the query to be answered.
-  , answerPreCheckoutQueryRequestOk                 :: Bool       -- ^ Specify 'True' if everything is alright (goods are available, etc.) and the bot is ready to proceed with the order. Use False if there are any problems.
-  , answerPreCheckoutQueryRequestErrorMessage       :: Maybe Text -- ^ Required if @ok@ is 'False'. Error message in human readable form that explains the reason for failure to proceed with the checkout (e.g. "Sorry, somebody just bought the last of our amazing black T-shirts while you were busy filling out your payment details. Please choose a different color or garment!"). Telegram will display this message to the user.
+  { answerPreCheckoutQueryPreCheckoutQueryId :: Text       -- ^ Unique identifier for the query to be answered.
+  , answerPreCheckoutQueryOk                 :: Bool       -- ^ Specify 'True' if everything is alright (goods are available, etc.) and the bot is ready to proceed with the order. Use False if there are any problems.
+  , answerPreCheckoutQueryErrorMessage       :: Maybe Text -- ^ Required if @ok@ is 'False'. Error message in human readable form that explains the reason for failure to proceed with the checkout (e.g. "Sorry, somebody just bought the last of our amazing black T-shirts while you were busy filling out your payment details. Please choose a different color or garment!"). Telegram will display this message to the user.
   }
   deriving (Generic, Show)
 

--- a/src/Telegram/Bot/API/Types.hs
+++ b/src/Telegram/Bot/API/Types.hs
@@ -11,1206 +11,191 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-module Telegram.Bot.API.Types where
+module Telegram.Bot.API.Types
+  ( RequiredQueryParam 
+  , module Telegram.Bot.API.Types.Animation
+  , module Telegram.Bot.API.Types.Audio
+  , module Telegram.Bot.API.Types.BotCommand
+  , module Telegram.Bot.API.Types.BotCommandScope
+  , module Telegram.Bot.API.Types.CallbackGame
+  , module Telegram.Bot.API.Types.CallbackQuery
+  , module Telegram.Bot.API.Types.Chat
+  , module Telegram.Bot.API.Types.ChatAdministratorRights
+  , module Telegram.Bot.API.Types.ChatInviteLink
+  , module Telegram.Bot.API.Types.ChatJoinRequest
+  , module Telegram.Bot.API.Types.ChatLocation
+  , module Telegram.Bot.API.Types.ChatMember
+  , module Telegram.Bot.API.Types.ChatMemberUpdated
+  , module Telegram.Bot.API.Types.ChatPermissions
+  , module Telegram.Bot.API.Types.ChatPhoto
+  , module Telegram.Bot.API.Types.ChatShared
+  , module Telegram.Bot.API.Types.Common
+  , module Telegram.Bot.API.Types.Contact
+  , module Telegram.Bot.API.Types.CopyMessageId
+  , module Telegram.Bot.API.Types.Dice
+  , module Telegram.Bot.API.Types.Document
+  , module Telegram.Bot.API.Types.EncryptedCredentials
+  , module Telegram.Bot.API.Types.EncryptedPassportElement
+  , module Telegram.Bot.API.Types.File
+  , module Telegram.Bot.API.Types.ForceReply
+  , module Telegram.Bot.API.Types.ForumTopic
+  , module Telegram.Bot.API.Types.ForumTopicEdited
+  , module Telegram.Bot.API.Types.ForumTopicClosed
+  , module Telegram.Bot.API.Types.ForumTopicCreated
+  , module Telegram.Bot.API.Types.ForumTopicReopened
+  , module Telegram.Bot.API.Types.Game
+  , module Telegram.Bot.API.Types.GameHighScore
+  , module Telegram.Bot.API.Types.GeneralForumTopicHidden
+  , module Telegram.Bot.API.Types.GeneralForumTopicUnhidden
+  , module Telegram.Bot.API.Types.InlineKeyboardButton
+  , module Telegram.Bot.API.Types.InlineKeyboardMarkup
+  , module Telegram.Bot.API.Types.InputMedia
+  , module Telegram.Bot.API.Types.Invoice
+  , module Telegram.Bot.API.Types.KeyboardButton
+  , module Telegram.Bot.API.Types.KeyboardButtonRequestChat
+  , module Telegram.Bot.API.Types.KeyboardButtonRequestUser
+  , module Telegram.Bot.API.Types.LabeledPrice
+  , module Telegram.Bot.API.Types.Location
+  , module Telegram.Bot.API.Types.LoginUrl
+  , module Telegram.Bot.API.Types.MaskPosition
+  , module Telegram.Bot.API.Types.MenuButton
+  , module Telegram.Bot.API.Types.Message
+  , module Telegram.Bot.API.Types.MessageAutoDeleteTimerChanged
+  , module Telegram.Bot.API.Types.MessageEntity
+  , module Telegram.Bot.API.Types.OrderInfo
+  , module Telegram.Bot.API.Types.PassportData
+  , module Telegram.Bot.API.Types.PassportElementError
+  , module Telegram.Bot.API.Types.PassportFile
+  , module Telegram.Bot.API.Types.PhotoSize
+  , module Telegram.Bot.API.Types.Poll
+  , module Telegram.Bot.API.Types.PollAnswer
+  , module Telegram.Bot.API.Types.PollOption
+  , module Telegram.Bot.API.Types.PollType
+  , module Telegram.Bot.API.Types.PreCheckoutQuery
+  , module Telegram.Bot.API.Types.ProximityAlertTriggered
+  , module Telegram.Bot.API.Types.ReplyKeyboardMarkup
+  , module Telegram.Bot.API.Types.ReplyKeyboardRemove
+  , module Telegram.Bot.API.Types.ResponseParameters
+  , module Telegram.Bot.API.Types.ShippingAddress
+  , module Telegram.Bot.API.Types.ShippingOption
+  , module Telegram.Bot.API.Types.ShippingQuery
+  , module Telegram.Bot.API.Types.Sticker
+  , module Telegram.Bot.API.Types.SuccessfulPayment
+  , module Telegram.Bot.API.Types.User
+  , module Telegram.Bot.API.Types.UserProfilePhotos
+  , module Telegram.Bot.API.Types.UserShared
+  , module Telegram.Bot.API.Types.Venue
+  , module Telegram.Bot.API.Types.Video
+  , module Telegram.Bot.API.Types.VideoChatEnded
+  , module Telegram.Bot.API.Types.VideoChatScheduled
+  , module Telegram.Bot.API.Types.VideoChatStarted
+  , module Telegram.Bot.API.Types.VideoNote
+  , module Telegram.Bot.API.Types.Voice
+  , module Telegram.Bot.API.Types.WebAppData
+  , module Telegram.Bot.API.Types.WriteAccessAllowed
+  ) where
 
-import Data.Aeson (ToJSON(..), FromJSON(..), Value(..), object, KeyValue ((.=)), withObject, (.:))
-import Data.Aeson.Types (Parser, Pair, Object)
-import Data.Aeson.Text (encodeToLazyText)
-import Data.Coerce (coerce)
-import Data.Bool (bool)
-import Data.Maybe (catMaybes)
-import Data.Functor ((<&>))
-import Data.Hashable (Hashable)
-import Data.String
-import Data.Text (Text, pack)
-import qualified Data.Text as Text
-import qualified Data.Text.Lazy as TL
-import Data.Time.Clock.POSIX (POSIXTime)
-import GHC.Generics (Generic)
 import Servant.API
-import Servant.Multipart.API
-import System.FilePath
 
-import Telegram.Bot.API.Internal.Utils
+
+import Telegram.Bot.API.Types.Animation
+import Telegram.Bot.API.Types.Audio
+import Telegram.Bot.API.Types.BotCommand
+import Telegram.Bot.API.Types.BotCommandScope
+import Telegram.Bot.API.Types.CallbackGame
+import Telegram.Bot.API.Types.CallbackQuery
+import Telegram.Bot.API.Types.Chat
+import Telegram.Bot.API.Types.ChatAdministratorRights
+import Telegram.Bot.API.Types.ChatInviteLink
+import Telegram.Bot.API.Types.ChatJoinRequest
+import Telegram.Bot.API.Types.ChatLocation
+import Telegram.Bot.API.Types.ChatMember
+import Telegram.Bot.API.Types.ChatMemberUpdated
+import Telegram.Bot.API.Types.ChatPermissions
+import Telegram.Bot.API.Types.ChatPhoto
+import Telegram.Bot.API.Types.ChatShared
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.Contact
+import Telegram.Bot.API.Types.CopyMessageId
+import Telegram.Bot.API.Types.Dice
+import Telegram.Bot.API.Types.Document
+import Telegram.Bot.API.Types.EncryptedCredentials
+import Telegram.Bot.API.Types.EncryptedPassportElement
+import Telegram.Bot.API.Types.File
+import Telegram.Bot.API.Types.ForceReply
+import Telegram.Bot.API.Types.ForumTopic
+import Telegram.Bot.API.Types.ForumTopicEdited
+import Telegram.Bot.API.Types.ForumTopicClosed
+import Telegram.Bot.API.Types.ForumTopicCreated
+import Telegram.Bot.API.Types.ForumTopicReopened
+import Telegram.Bot.API.Types.Game
+import Telegram.Bot.API.Types.GameHighScore
+import Telegram.Bot.API.Types.GeneralForumTopicHidden
+import Telegram.Bot.API.Types.GeneralForumTopicUnhidden
+import Telegram.Bot.API.Types.InlineKeyboardButton
+import Telegram.Bot.API.Types.InlineKeyboardMarkup
+import Telegram.Bot.API.Types.InputMedia
+import Telegram.Bot.API.Types.Invoice
+import Telegram.Bot.API.Types.KeyboardButton
+import Telegram.Bot.API.Types.KeyboardButtonRequestChat
+import Telegram.Bot.API.Types.KeyboardButtonRequestUser
+import Telegram.Bot.API.Types.LabeledPrice
+import Telegram.Bot.API.Types.Location
+import Telegram.Bot.API.Types.LoginUrl
+import Telegram.Bot.API.Types.MaskPosition
+import Telegram.Bot.API.Types.MenuButton
+import Telegram.Bot.API.Types.Message
+import Telegram.Bot.API.Types.MessageAutoDeleteTimerChanged
+import Telegram.Bot.API.Types.MessageEntity
+import Telegram.Bot.API.Types.OrderInfo
+import Telegram.Bot.API.Types.PassportData
+import Telegram.Bot.API.Types.PassportElementError
+import Telegram.Bot.API.Types.PassportFile
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Types.Poll
+import Telegram.Bot.API.Types.PollAnswer
+import Telegram.Bot.API.Types.PollOption
+import Telegram.Bot.API.Types.PollType
+import Telegram.Bot.API.Types.PreCheckoutQuery
+import Telegram.Bot.API.Types.ProximityAlertTriggered
+import Telegram.Bot.API.Types.ReplyKeyboardMarkup
+import Telegram.Bot.API.Types.ReplyKeyboardRemove
+import Telegram.Bot.API.Types.ResponseParameters
+import Telegram.Bot.API.Types.ShippingAddress
+import Telegram.Bot.API.Types.ShippingOption
+import Telegram.Bot.API.Types.ShippingQuery
+import Telegram.Bot.API.Types.Sticker
+import Telegram.Bot.API.Types.SuccessfulPayment
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Types.UserProfilePhotos
+import Telegram.Bot.API.Types.UserShared
+import Telegram.Bot.API.Types.Venue
+import Telegram.Bot.API.Types.Video
+import Telegram.Bot.API.Types.VideoChatEnded
+import Telegram.Bot.API.Types.VideoChatScheduled
+import Telegram.Bot.API.Types.VideoChatStarted
+import Telegram.Bot.API.Types.VideoNote
+import Telegram.Bot.API.Types.Voice
+import Telegram.Bot.API.Types.WebAppData
+import Telegram.Bot.API.Types.WriteAccessAllowed
 
 type RequiredQueryParam = QueryParam' '[Required , Strict]
 
-newtype Seconds = Seconds Int
-  deriving (Eq, Show, Num, ToJSON, FromJSON)
-
 -- * Available types
 
--- ** User
 
--- | This object represents a Telegram user or bot.
---
--- <https://core.telegram.org/bots/api#user>
-data User = User
-  { userId           :: UserId     -- ^ Unique identifier for this user or bot.
-  , userIsBot        :: Bool       -- ^ 'True', if this user is a bot.
-  , userFirstName    :: Text       -- ^ User's or bot's first name.
-  , userLastName     :: Maybe Text -- ^ User‘s or bot’s last name.
-  , userUsername     :: Maybe Text -- ^ User‘s or bot’s username.
-  , userLanguageCode :: Maybe Text -- ^ IETF language tag of the user's language.
-  , userIsPremium    :: Maybe Bool -- ^ 'True', if this user is a Telegram Premium user.
-  , userAddedToAttachmentMenu :: Maybe Bool -- ^ 'True', if this user added the bot to the attachment menu.
-  , userCanJoinGroups :: Maybe Bool -- ^ 'True', if the bot can be invited to groups. Returned only in `getMe`.
-  , userCanReadAllGroupMessages :: Maybe Bool -- ^ 'True', if privacy mode is disabled for the bot. Returned only in `getMe`.
-  , userSupportsInlineQueries :: Maybe Bool -- ^ 'True', if the bot supports inline queries. Returned only in `getMe`.
-  }
-  deriving (Show, Generic)
 
--- | Unique identifier for this user or bot.
-newtype UserId = UserId Integer
-  deriving (Eq, Show, ToJSON, FromJSON)
-
-instance ToHttpApiData UserId where
-  toUrlPiece = pack . show @Integer . coerce
-
--- ** Chat
-
--- | This object represents a chat.
---
--- <https://core.telegram.org/bots/api#chat>
-data Chat = Chat
-  { chatId               :: ChatId          -- ^ Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
-  , chatType             :: ChatType        -- ^ Type of chat.
-  , chatTitle            :: Maybe Text      -- ^ Title, for supergroups, channels and group chats
-  , chatUsername         :: Maybe Text      -- ^ Username, for private chats, supergroups and channels if available
-  , chatFirstName        :: Maybe Text      -- ^ First name of the other party in a private chat
-  , chatLastName         :: Maybe Text      -- ^ Last name of the other party in a private chat
-  , chatIsForum          :: Maybe Bool      -- ^ 'True', if the supergroup chat is a forum (has topics enabled).
-  , chatPhoto            :: Maybe ChatPhoto -- ^ Chat photo. Returned only in getChat.
-  , chatActiveUsernames  :: Maybe Text      -- ^ If non-empty, the list of all active chat usernames; for private chats, supergroups and channels. Returned only in 'getChat'.
-  , chatEmojiStatusCustomEmojiId :: Maybe Text -- ^ Custom emoji identifier of emoji status of the other party in a private chat. Returned only in 'getChat'.
-  , chatBio              :: Maybe Text      -- ^ Bio of the other party in a private chat. Returned only in `getChat`.
-  , chatHasPrivateForwards :: Maybe Bool    -- ^ 'True', if privacy settings of the other party in the private chat allows to use `tg://user?id=<user_id>` links only in chats with the user. Returned only in getChat.
-  , chatHasRestrictedVoiceAndVideoMessages :: Maybe Bool -- ^ 'True', if the privacy settings of the other party restrict sending voice and video note messages in the private chat. Returned only in 'getChat'.
-  , chatJoinToSendMessages :: Maybe Bool    -- ^ 'True', if users need to join the supergroup before they can send messages. Returned only in 'getChat'.
-  , chatJoinByRequest    :: Maybe Bool      -- ^ 'True', if all users directly joining the supergroup need to be approved by supergroup administrators. Returned only in 'getChat'.
-  , chatDescription      :: Maybe Text      -- ^ Description, for supergroups and channel chats. Returned only in getChat.
-  , chatInviteLink       :: Maybe Text      -- ^ Chat invite link, for supergroups and channel chats. Returned only in getChat.
-  , chatPinnedMessage    :: Maybe Message   -- ^ Pinned message, for supergroups. Returned only in getChat.
-  , chatPermissions      :: Maybe ChatPermissions -- ^ Default chat member permissions, for groups and supergroups.
-  , chatSlowModeDelay    :: Maybe Int       -- ^ For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user; in seconds.
-  , chatMessageAutoDeleteTime :: Maybe POSIXTime -- ^ The time after which all messages sent to the chat will be automatically deleted; in seconds.
-  , chatHasProtectedContent :: Maybe Bool   -- ^ 'True', if messages from the chat can't be forwarded to other chats.
-  , chatStickerSetName   :: Maybe Text      -- ^ For supergroups, name of group sticker set. Returned only in getChat.
-  , chatCanSetStickerSet :: Maybe Bool      -- ^ True, if the bot can change the group sticker set. Returned only in `getChat`.
-  , chatLinkedChatId     :: Maybe ChatId    -- ^ Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. This identifier may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
-  , chatLocation         :: Maybe ChatLocation -- ^ For supergroups, the location to which the supergroup is connected. Returned only in getChat.
-  }
-  deriving (Generic, Show)
-
--- | Unique identifier for this chat.
-newtype ChatId = ChatId Integer
-  deriving (Eq, Show, ToJSON, FromJSON, Hashable)
-
-instance ToHttpApiData ChatId where
-  toUrlPiece a = pack . show @Integer $ coerce a
-
--- | Type of chat.
-data ChatType
-  = ChatTypePrivate
-  | ChatTypeGroup
-  | ChatTypeSupergroup
-  | ChatTypeChannel
-  deriving (Generic, Show)
-
-instance ToJSON   ChatType where
-  toJSON = gtoJSON
-instance FromJSON ChatType where
-  parseJSON = gparseJSON
-
--- ** Message
-
--- | This object represents a message.
-data Message = Message
-  { messageMessageId             :: MessageId -- ^ Unique message identifier inside this chat.
-  , messageMessageThreadId       :: Maybe MessageThreadId -- ^ Unique identifier of a message thread to which the message belongs; for supergroups only.
-  , messageFrom                  :: Maybe User -- ^ Sender, empty for messages sent to channels.
-  , messageSenderChat            :: Maybe Chat -- ^ Sender of the message, sent on behalf of a chat. For example, the channel itself for channel posts, the supergroup itself for messages from anonymous group administrators, the linked channel for messages automatically forwarded to the discussion group. For backward compatibility, the field from contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
-  , messageDate                  :: POSIXTime -- ^ Date the message was sent in Unix time.
-  , messageChat                  :: Chat -- ^ Conversation the message belongs to.
-  , messageForwardFrom           :: Maybe User -- ^ For forwarded messages, sender of the original message.
-  , messageForwardFromChat       :: Maybe Chat -- ^ For messages forwarded from channels, information about the original channel.
-  , messageForwardFromMessageId  :: Maybe MessageId -- ^ For messages forwarded from channels, identifier of the original message in the channel.
-  , messageForwardSignature      :: Maybe Text -- ^ For messages forwarded from channels, signature of the post author if present.
-  , messageForwardSenderName     :: Maybe Text -- ^ Sender's name for messages forwarded from users who disallow adding a link to their account in forwarded messages.
-  , messageForwardDate           :: Maybe POSIXTime -- ^ For forwarded messages, date the original message was sent in Unix time
-  , messageIsTopicMessage        :: Maybe Bool -- ^ 'True', if the message is sent to a forum topic.
-  , messageIsAutomaticForward    :: Maybe Bool -- ^ 'True', if the message is a channel post that was automatically forwarded to the connected discussion group.
-  , messageReplyToMessage        :: Maybe Message -- ^ For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
-  , messageViaBot                :: Maybe User -- ^ Bot through which the message was sent.
-  , messageEditDate              :: Maybe POSIXTime -- ^ Date the message was last edited in Unix time
-  , messageHasProtectedContent   :: Maybe Bool -- ^ 'True', if the message can't be forwarded.
-  , messageMediaGroupId          :: Maybe MediaGroupId -- ^ The unique identifier of a media message group this message belongs to
-  , messageAuthorSignature       :: Maybe Text -- ^ Signature of the post author for messages in channels
-  , messageText                  :: Maybe Text -- ^ For text messages, the actual UTF-8 text of the message, 0-4096 characters.
-  , messageEntities              :: Maybe [MessageEntity] -- ^ For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text
-  , messageAnimation             :: Maybe Animation -- ^ Message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set.
-  , messageAudio                 :: Maybe Audio -- ^ Message is an audio file, information about the file
-  , messageDocument              :: Maybe Document -- ^ Message is a general file, information about the file.
-  , messagePhoto                 :: Maybe [PhotoSize] -- ^ Message is a photo, available sizes of the photo
-  , messageSticker               :: Maybe Sticker -- ^ Message is a sticker, information about the sticker
-  , messageVideo                 :: Maybe Video -- ^ Message is a video, information about the video
-  , messageVideoNote             :: Maybe VideoNote -- ^ Message is a video note, information about the video message
-  , messageVoice                 :: Maybe Voice -- ^ Message is a voice message, information about the file
-  , messageCaption               :: Maybe Text -- ^ Caption for the audio, document, photo, video or voice, 0-200 characters
-  , messageCaptionEntities       :: Maybe [MessageEntity] -- ^ For messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption.
-  , messageHasMediaSpoiler       :: Maybe Bool -- ^ 'True', if the message media is covered by a spoiler animation.
-  , messageContact               :: Maybe Contact -- ^ Message is a shared contact, information about the contact
-  , messageDice                  :: Maybe Dice -- ^ Message is a dice with random value.
-  , messageGame                  :: Maybe Game -- ^ Message is a game, information about the game. More about games »  , messageLocation              :: Maybe Location -- ^ Message is a shared location, information about the location
-  , messagePoll                  :: Maybe Poll -- ^ Message is a native poll, information about the poll.
-  , messageVenue                 :: Maybe Venue -- ^ Message is a venue, information about the venue
-  , messageLocation              :: Maybe Location -- ^ Message is a shared location, information about the location.
-  , messageNewChatMembers        :: Maybe [User] -- ^ New members that were added to the group or supergroup and information about them (the bot itself may be one of these members)
-  , messageLeftChatMember        :: Maybe User -- ^ A member was removed from the group, information about them (this member may be the bot itself)
-  , messageNewChatTitle          :: Maybe Text -- ^ A chat title was changed to this value
-  , messageNewChatPhoto          :: Maybe [PhotoSize] -- ^ A chat photo was change to this value
-  , messageDeleteChatPhoto       :: Maybe Bool -- ^ Service message: the chat photo was deleted
-  , messageGroupChatCreated      :: Maybe Bool -- ^ Service message: the group has been created
-  , messageSupergroupChatCreated :: Maybe Bool -- ^ Service message: the supergroup has been created. This field can‘t be received in a message coming through updates, because bot can’t be a member of a supergroup when it is created. It can only be found in reply_to_message if someone replies to a very first message in a directly created supergroup.
-  , messageChannelChatCreated    :: Maybe Bool -- ^ Service message: the channel has been created. This field can‘t be received in a message coming through updates, because bot can’t be a member of a channel when it is created. It can only be found in reply_to_message if someone replies to a very first message in a channel.
-  , messageAutoDeleteTimerChanged :: Maybe MessageAutoDeleteTimerChanged -- ^ Service message: auto-delete timer settings changed in the chat.
-  , messageHasAggressiveAntiSpamEnabled :: Maybe Bool -- ^ 'True', if aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. Returned only in 'getChat'.
-  , messageHasHiddenMembers      :: Maybe Bool -- ^ 'True', if non-administrators can only get the list of bots and administrators in the chat. Returned only in 'getChat'.
-  , messageMigrateToChatId       :: Maybe ChatId -- ^ The group has been migrated to a supergroup with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
-  , messageMigrateFromChatId     :: Maybe ChatId -- ^ The supergroup has been migrated from a group with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
-  , messagePinnedMessage         :: Maybe Message -- ^ Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.
-  , messageInvoice               :: Maybe Invoice -- ^ Message is an invoice for a payment, information about the invoice.
-  , messageSuccessfulPayment     :: Maybe SuccessfulPayment -- ^ Message is a service message about a successful payment, information about the payment.
-  , messageUserShared            :: Maybe UserShared -- ^ Service message: a user was shared with the bot.
-  , messageChatShared            :: Maybe ChatShared -- ^ Service message: a chat was shared with the bot.
-  , messageConnectedWebsite      :: Maybe Text -- ^ The domain name of the website on which the user has logged in.
-  , messageWriteAccessAllowed    :: Maybe WriteAccessAllowed -- ^ Service message: the user allowed the bot added to the attachment menu to write messages.
-  , messagePassportData          :: Maybe PassportData -- ^ Telegram Passport data.
-  , messageProximityAlertTriggered :: Maybe ProximityAlertTriggered -- ^ Service message. A user in the chat triggered another user's proximity alert while sharing Live Location.
-  , messageForumTopicCreated     :: Maybe ForumTopicCreated -- ^ Service message: forum topic created.
-  , messageForumTopicEdited     :: Maybe ForumTopicEdited -- ^ Service message: forum topic edited.
-  , messageForumTopicClosed     :: Maybe ForumTopicClosed -- ^ Service message: forum topic closed.
-  , messageForumTopicReopened     :: Maybe ForumTopicReopened -- ^ Service message: forum topic reopened.
-  , messageVideoChatScheduled    :: Maybe VideoChatScheduled -- ^ Service message: video chat scheduled.
-  , messageVideoChatStarted      :: Maybe VideoChatStarted -- ^ Service message: video chat started
-  , messageVideoChatEnded        :: Maybe VideoChatEnded -- ^ Service message: video chat ended.
-  , messageVideoChatParticipantsInvited :: Maybe VideoChatParticipantsInvited -- ^ Service message: new participants invited to a video chat.
-  , messageWebAppData            :: Maybe WebAppData -- ^ Service message: data sent by a Web App.
-  , messageReplyMarkup           :: Maybe InlineKeyboardMarkup -- ^ Inline keyboard attached to the message. `login_url` buttons are represented as ordinary `url` buttons.
-  }
-  deriving (Generic, Show)
-
--- | Unique message identifier inside this chat.
-newtype MessageId = MessageId Integer
-  deriving (Eq, Show, ToJSON, FromJSON, Hashable)
-
-instance ToHttpApiData MessageId where
-  toUrlPiece a = pack . show @Integer $ coerce a
-
--- | Unique identifier of a message thread to which the message belongs; for supergroups only.
-newtype MessageThreadId = MessageThreadId Integer
-  deriving (Eq, Show, ToJSON, FromJSON, Hashable)
-
-instance ToHttpApiData MessageThreadId where
-  toUrlPiece a = pack . show @Integer $ coerce a
-
--- | The unique identifier of a media message group a message belongs to.
-newtype MediaGroupId = MediaGroupId Text
-  deriving (Eq, Show, ToJSON, FromJSON)
-
--- | Signed 32-bit identifier of the request, which will be received back in the 'UserShared' or 'ChatShared' object. Must be unique within the message.
-newtype RequestId = RequestId Integer
-  deriving (Eq, Show, ToJSON, FromJSON)
-
--- ** MessageEntity
-
--- | This object represents one special entity in a text message. For example, hashtags, usernames, URLs, etc.
-data MessageEntity = MessageEntity
-  { messageEntityType   :: MessageEntityType -- ^ Type of the entity. Can be mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text), underline (underlined text), strikethrough, code (monowidth string), pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames)
-  , messageEntityOffset :: Int -- ^ Offset in UTF-16 code units to the start of the entity
-  , messageEntityLength :: Int -- ^ Length of the entity in UTF-16 code units
-  , messageEntityUrl    :: Maybe Text -- ^ For “text_link” only, url that will be opened after user taps on the text
-  , messageEntityUser   :: Maybe User -- ^ For “text_mention” only, the mentioned user
-  , messageEntityLanguage :: Maybe Text -- ^ For “pre” only, the programming language of the entity text.
-  , messageEntityCustomEmojiId :: Maybe Text -- ^ For “custom_emoji” only, unique identifier of the custom emoji. Use @getCustomEmojiStickers@ to get full information about the sticker.
-  }
-  deriving (Generic, Show)
-
--- | Type of the entity. Can be mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text), underline (underlined text), strikethrough, code (monowidth string), pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames), cashtag, phone_number
-data MessageEntityType
-  = MessageEntityMention
-  | MessageEntityHashtag
-  | MessageEntityBotCommand
-  | MessageEntityUrl
-  | MessageEntityEmail
-  | MessageEntityBold
-  | MessageEntityItalic
-  | MessageEntityUnderline -- ^ See <https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_underline.html>
-  | MessageEntityStrikethrough -- ^ See <https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_strikethrough.html>
-  | MessageEntityCode
-  | MessageEntityPre
-  | MessageEntityTextLink
-  | MessageEntityTextMention
-  | MessageEntityCashtag -- ^ See <https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_cashtag.html>.
-  | MessageEntityPhoneNumber -- ^ See <https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_phone_number.html>.
-  | MessageEntitySpoiler
-  | MessageEntityCustomEmoji
-  deriving (Eq, Show, Generic)
-
--- ** 'PhotoSize'
-
--- | This object represents one size of a photo or a file / sticker thumbnail.
-data PhotoSize = PhotoSize
-  { photoSizeFileId       :: FileId      -- ^ Unique identifier for this file.
-  , photoSizeFileUniqueId :: FileId      -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , photoSizeWidth        :: Int       -- ^ Photo width
-  , photoSizeHeight       :: Int       -- ^ Photo height
-  , photoSizeFileSize     :: Maybe Int -- ^ File size
-  }
-  deriving (Generic, Show)
-
--- | Unique identifier for this file.
-newtype FileId = FileId Text
-  deriving (Eq, Show, ToJSON, FromJSON)
-
-instance ToHttpApiData FileId where
-  toUrlPiece = coerce
-
--- ** 'Animation'
-
--- | This object represents an animation file (GIF or H.264/MPEG-4 AVC video without sound).
-data Animation = Animation
-  { animationFileId       :: FileId          -- ^ Identifier for this file, which can be used to download or reuse the file.
-  , animationFileUniqueId :: FileId          -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , animationWidth        :: Int           -- ^ Video width as defined by sender.
-  , animationHeight       :: Int           -- ^ Video height as defined by sender.
-  , animationDuration     :: Seconds         -- ^ Duration of the video in seconds as defined by sender.
-  , animationThumb        :: Maybe PhotoSize -- ^ Animation thumbnail as defined by sender.
-  , animationFileName     :: Maybe Text      -- ^ Original animation filename as defined by sender.
-  , animationMimeType     :: Maybe Text      -- ^ MIME type of the file as defined by sender.
-  , animationFileSize     :: Maybe Integer   -- ^ File size in bytes.
-  }
-  deriving (Generic, Show)
-
--- ** 'Audio'
-
--- | This object represents an audio file to be treated as music by the Telegram clients.
-data Audio = Audio
-  { audioFileId    :: FileId -- ^ Unique identifier for this file.
-  , audioFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , audioDuration  :: Seconds -- ^ Duration of the audio in seconds as defined by sender.
-  , audioPerformer :: Maybe Text -- ^ Performer of the audio as defined by sender or by audio tags.
-  , audioTitle     :: Maybe Text -- ^ Title of the audio as defined by sender or by audio tags.
-  , audioFileName  :: Maybe Text -- ^ Original filename as defined by sender.
-  , audioMimeType  :: Maybe Text -- ^ MIME type of the file as defined by sender.
-  , audioFileSize  :: Maybe Integer -- ^ File size in bytes.
-  , audioThumb     :: Maybe PhotoSize -- ^ Thumbnail of the album cover to which the music file belongs.
-  }
-  deriving (Generic, Show)
-
--- ** 'Document'
-
--- | This object represents a general file (as opposed to photos, voice messages and audio files).
-data Document = Document
-  { documentFileId   :: FileId -- ^ Unique file identifier.
-  , documentFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , documentThumb    :: Maybe PhotoSize -- ^ Document thumbnail as defined by sender.
-  , documentFileName :: Maybe Text -- ^ Original filename as defined by sender.
-  , documentMimeType :: Maybe Text -- ^ MIME type of the file as defined by sender.
-  , documentFileSize :: Maybe Integer -- ^ File size in bytes. 
-  }
-  deriving (Generic, Show)
-
--- ** 'Video'
-
--- | This object represents a video file.
-data Video = Video
-  { videoFileId       :: FileId -- ^ Unique identifier for this file.
-  , videoFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , videoWidth        :: Int -- ^ Video width as defined by sender.
-  , videoHeight       :: Int -- ^ Video height as defined by sender.
-  , videoDuration     :: Seconds -- ^ Duration of the video in seconds as defined by sender.
-  , videoThumb        :: Maybe PhotoSize -- ^ Video thumbnail.
-  , videoFileName     :: Maybe Text -- ^ Original filename as defined by sender.
-  , videoMimeType     :: Maybe Text -- ^ Mime type of a file as defined by sender.
-  , videoFileSize     :: Maybe Integer -- ^ File size in bytes.
-  }
-  deriving (Generic, Show)
-
--- ** 'VideoNote'
-
--- | This object represents a video message (available in Telegram apps as of v.4.0).
-data VideoNote = VideoNote
-  { videoNoteFileId   :: FileId -- ^ Unique identifier for this file.
-  , videoNoteFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , videoNoteLength   :: Int -- ^ Video width and height as defined by sender.
-  , videoNoteDuration :: Seconds -- ^ Duration of the video in seconds as defined by sender.
-  , videoNoteThumb    :: Maybe PhotoSize -- ^ Video thumbnail.
-  , videoNoteFileSize :: Maybe Integer -- ^ File size in bytes.
-  }
-  deriving (Generic, Show)
-
--- ** 'Voice'
-
--- | This object represents a voice note.
-data Voice = Voice
-  { voiceFileId   :: FileId -- ^ Unique identifier for this file.
-  , voiceFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , voiceDuration :: Seconds -- ^ Duration of the audio in seconds as defined by sender.
-  , voiceMimeType :: Maybe Text -- ^ MIME type of the file as defined by sender.
-  , voiceFileSize :: Maybe Integer -- ^ File size in bytes.
-  }
-  deriving (Generic, Show)
-
--- ** 'Contact'
-
--- | This object represents a phone contact.
-data Contact = Contact
-  { contactPhoneNumber :: Text -- ^ Contact's phone number.
-  , contactFirstName   :: Text -- ^ Contact's first name.
-  , contactLastName    :: Maybe Text -- ^ Contact's last name.
-  , contactUserId      :: Maybe UserId -- ^ Contact's user identifier in Telegram.
-  , contactVcard       :: Maybe Text -- ^ Additional data about the contact in the form of a vCard.
-  }
-  deriving (Generic, Show)
-
--- ** 'Dice'
-
--- | This object represents an animated emoji that displays a random value.
-data Dice = Dice
-  { diceEmoji :: Text -- ^ Emoji on which the dice throw animation is based.
-  , diceValue :: Int  -- ^ Value of the dice, 1-6 for “🎲”, “🎯” and “🎳” base emoji, 1-5 for “🏀” and “⚽” base emoji, 1-64 for “🎰” base emoji
-  }
-  deriving (Generic, Show)
-
--- ** 'PollOption'
-
--- | This object contains information about one answer option in a poll.
-data PollOption = PollOption
-  { pollOptionText       :: Text -- ^ Option text, 1-100 characters.
-  , pollOptionVoterCount :: Int  -- ^ Number of users that voted for this option.
-  }
-  deriving (Generic, Show)
-
--- ** 'PollAnswer'
-
--- | This object represents an answer of a user in a non-anonymous poll.
-data PollAnswer = PollAnswer
-  { pollAnswerPollId    :: PollId -- ^ Unique poll identifier.
-  , pollAnswerUser      :: User   -- ^ The user, who changed the answer to the poll.
-  , pollAnswerOptionIds :: [Int]  -- ^ 0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.
-  }
-  deriving (Generic, Show)
-
--- | Unique poll identifier.
-newtype PollId = PollId Text
-  deriving (Eq, Show, ToJSON, FromJSON)
-
--- ** 'Poll'
-
-data Poll = Poll
-  { pollId                    :: PollId                -- ^ Unique poll identifier.
-  , pollQuestion              :: Text                  -- ^ Poll question, 1-300 characters.
-  , pollOptions               :: [PollOption]          -- ^ List of poll options.
-  , pollTotalVoterCount       :: Int                 -- ^ Total number of users that voted in the poll.
-  , pollIsClosed              :: Bool                  -- ^ 'True', if the poll is closed.
-  , pollIsAnonymous           :: Bool                  -- ^ 'True', if the poll is anonymous.
-  , pollType                  :: PollType              -- ^ Poll type, currently can be “regular” or “quiz”.
-  , pollAllowsMultipleAnswers :: Bool                  -- ^ 'True', if the poll allows multiple answers.
-  , pollCorrectOptionId       :: Maybe Int             -- ^ 0-based identifier of the correct answer option. Available only for polls in the quiz mode, which are closed, or was sent (not forwarded) by the bot or to the private chat with the bot.
-  , pollExplanation           :: Maybe Text            -- ^ Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters.
-  , pollExplanationEntities   :: Maybe [MessageEntity] -- ^ Special entities like usernames, URLs, bot commands, etc. that appear in the explanation.
-  , pollOpenPeriod            :: Maybe Seconds         -- ^ Amount of time in seconds the poll will be active after creation.
-  , pollCloseData             :: Maybe POSIXTime       -- ^ Point in time (Unix timestamp) when the poll will be automatically closed.
-  }
-  deriving (Generic, Show)
-
--- ** Location
-
--- | This object represents a point on the map.
-data Location = Location
-  { locationLongitude            :: Float         -- ^ Longitude as defined by sender.
-  , locationLatitude             :: Float         -- ^ Latitude as defined by sender.
-  , locationHorizontalAccuracy   :: Maybe Float   -- ^ The radius of uncertainty for the location, measured in meters; 0-1500.
-  , locationLivePeriod           :: Maybe Seconds -- ^ Time relative to the message sending date, during which the location can be updated; in seconds. For active live locations only.
-  , locationHeading              :: Maybe Int     -- ^ The direction in which user is moving, in degrees; 1-360. For active live locations only.
-  , locationProximityAlertRadius :: Maybe Int     -- ^ Maximum distance for proximity alerts about approaching another chat member, in meters. For sent live locations only.
-  }
-  deriving (Generic, Show)
-
--- ** 'Venue'
-
--- | This object represents a venue.
-data Venue = Venue
-  { venueLocation        :: Location   -- ^ Venue location.
-  , venueTitle           :: Text       -- ^ Name of the venue.
-  , venueAddress         :: Text       -- ^ Address of the venue.
-  , venueFoursquareId    :: Maybe Text -- ^ Foursquare identifier of the venue.
-  , venueFoursquareType  :: Maybe Text -- ^ Foursquare type of the venue. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
-  , venueGooglePlaceId   :: Maybe Text -- ^ Google Places identifier of the venue.
-  , venueGooglePlaceType :: Maybe Text -- ^ Google Places type of the venue. (See supported types.)
-  }
-  deriving (Generic, Show)
-
--- ** 'ProximityAlertTriggered'
-
--- | This object represents the content of a service message, sent whenever a user in the chat triggers a proximity alert set by another user.
-data ProximityAlertTriggered = ProximityAlertTriggered
-  { proximityAlertTriggeredTraveler :: User  -- ^ User that triggered the alert.
-  , proximityAlertTriggeredWatcher  :: User  -- ^ User that set the alert.
-  , proximityAlertTriggeredDistance :: Int -- ^ The distance between the users.
-  }
-  deriving (Generic, Show)
-
--- ** 'MessageAutoDeleteTimerChanged'
-
--- | This object represents a service message about a change in auto-delete timer settings.
-data MessageAutoDeleteTimerChanged = MessageAutoDeleteTimerChanged
-  { messageAutoDeleteTimerChangedMessageAutoDeleteTime :: Seconds -- ^ New auto-delete time for messages in the chat; in seconds
-  }
-  deriving (Generic, Show)
-
--- ** 'ForumTopicCreated'
-
--- | This object represents a service message about a new forum topic created in the chat.
-data ForumTopicCreated = ForumTopicCreated
-  { forumTopicCreatedName              :: Text       -- ^ Name of the topic.
-  , forumTopicCreatedIconColor         :: Integer    -- ^ Color of the topic icon in RGB format.
-  , forumTopicCreatedIconCustomEmojiId :: Maybe Text -- ^ Unique identifier of the custom emoji shown as the topic icon.
-  }
-  deriving (Generic, Show)
-
--- ** 'ForumTopicClosed'
-
--- | This object represents a service message about a forum topic closed in the chat. Currently holds no information.
-newtype ForumTopicClosed = ForumTopicClosed Object
-  deriving (Generic, Show)
-
--- ** 'ForumTopicEdited'
-
--- | This object represents a service message about an edited forum topic.
-data ForumTopicEdited = ForumTopicEdited
-  { forumTopicEditedName              :: Maybe Text -- ^ New name of the topic, if it was edited.
-  , forumTopicEditedIconCustomEmojiId :: Maybe Text -- ^ New identifier of the custom emoji shown as the topic icon, if it was edited; an empty string if the icon was removed.
-  }
-  deriving (Generic, Show)
-
--- ** 'ForumTopicReopened'
-
--- | This object represents a service message about a forum topic reopened in the chat. Currently holds no information.
-newtype ForumTopicReopened = ForumTopicReopened Object
-  deriving (Generic, Show)
-
--- ** 'GeneralForumTopicHidden'
-
--- | This object represents a service message about General forum topic hidden in the chat. Currently holds no information.
-newtype GeneralForumTopicHidden = GeneralForumTopicHidden Object
-  deriving (Generic, Show)
-
--- ** 'GeneralForumTopicUnhidden'
-
--- | This object represents a service message about General forum topic unhidden in the chat. Currently holds no information.
-newtype GeneralForumTopicUnhidden = GeneralForumTopicUnhidden Object
-  deriving (Generic, Show)
-
--- ** 'UserShared'
-
--- | This object contains information about the user whose identifier was shared with the bot using a 'KeyboardButtonRequestUser' button.
-data UserShared = UserShared
-  { userSharedRequestId :: RequestId -- ^ Identifier of the request.
-  , userSharedUserId :: UserId -- ^ Identifier of the shared user. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means.
-  }
-  deriving (Generic, Show)
-
--- ** 'ChatShared'
-
--- | This object contains information about the chat whose identifier was shared with the bot using a 'KeyboardButtonRequestChat' button.
-data ChatShared = ChatShared
-  { chatSharedRequestId :: RequestId -- ^ Identifier of the request.
-  , chatSharedChatId :: ChatId -- ^ Identifier of the shared chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the chat and could be unable to use this identifier, unless the chat is already known to the bot by some other means.
-  }
-  deriving (Generic, Show)
-
--- ** 'WriteAccessAllowed'
-
--- | This object represents a service message about a user allowing a bot added to the attachment menu to write messages. Currently holds no information.
-newtype WriteAccessAllowed = WriteAccessAllowed Object
-  deriving (Generic, Show)
-
--- ** 'VideoChatScheduled'
-
--- | This object represents a service message about a video chat scheduled in the chat.
-data VideoChatScheduled = VideoChatScheduled
-  { videoChatScheduledStartDate :: POSIXTime -- ^ Point in time (Unix timestamp) when the video chat is supposed to be started by a chat administrator.
-  }
-  deriving (Generic, Show)
-
--- ** 'VideoChatStarted'
-
--- | This object represents a service message about a video chat started in the chat. Currently holds no information.
-data VideoChatStarted = VideoChatStarted
-  deriving (Generic, Show)
-
-instance ToJSON VideoChatStarted where
-  toJSON = gtoJSON
-
-instance FromJSON VideoChatStarted where
-  parseJSON (Data.Aeson.Object _) = pure VideoChatStarted
-  parseJSON _ = fail "Unable to parse VideoChatStarted: expected an empty object"
-
--- ** 'VideoChatEnded'
-
--- | This object represents a service message about a video chat ended in the chat.
-data VideoChatEnded = VideoChatEnded
-  { videoChatEndedDuration :: Seconds -- ^ Video chat duration in seconds.
-  }
-  deriving (Generic, Show)
-
--- ** 'VideoChatParticipantsInvited'
-data VideoChatParticipantsInvited = VideoChatParticipantsInvited
-  { videoChatParticipantsInvitedUsers :: Maybe [User] -- ^ New members that were invited to the video chat.
-  }
-  deriving (Generic, Show)
-
--- ** 'UserProfilePhotos'
-
--- | This object represent a user's profile pictures.
-data UserProfilePhotos = UserProfilePhotos
-  { userProfilePhotosTotalCount :: Int -- ^ Total number of profile pictures the target user has
-  , userProfilePhotosPhotos     :: [[PhotoSize]] -- ^ Requested profile pictures (in up to 4 sizes each)
-  }
-  deriving (Generic, Show)
-
--- ** 'WebAppData'
-
-data WebAppData = WebAppData
-  { webAppDataData       :: Text -- ^ The data. Be aware that a bad client can send arbitrary data in this field.
-  , webAppDataButtonText :: Text -- ^ Text of the @web_app@ keyboard button, from which the Web App was opened. Be aware that a bad client can send arbitrary data in this field.
-  }
-  deriving (Generic, Show)
-
--- ** 'File'
-
--- | This object represents a file ready to be downloaded.
--- The file can be downloaded via the link @https://api.telegram.org/file/bot<token>/<file_path>@.
--- It is guaranteed that the link will be valid for at least 1 hour.
--- When the link expires, a new one can be requested by calling getFile.
-data File = File
-  { fileFileId       :: FileId      -- ^ Unique identifier for this file.
-  , fileFileUniqueId :: FileId      -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , fileFileSize     :: Maybe Integer -- ^ File size in bytes, if known.
-  , fileFilePath     :: Maybe Text  -- ^ File path. Use https://api.telegram.org/file/bot<token>/<file_path> to get the file.
-  }
-  deriving (Generic, Show)
-
-type ContentType = Text
-
-data InputFile
-  = InputFileId FileId
-  | FileUrl Text
-  | InputFile FilePath ContentType
-
-instance ToJSON InputFile where
-  toJSON (InputFileId i) = toJSON i
-  toJSON (FileUrl t) = toJSON t
-  toJSON (InputFile f _) = toJSON ("attach://" <> pack (takeFileName f))
-
--- ** 'ReplyKeyboardMarkup'
-
--- | This object represents a custom keyboard with reply options (see Introduction to bots for details and examples).
-data ReplyKeyboardMarkup = ReplyKeyboardMarkup
-  { replyKeyboardMarkupKeyboard           :: [[KeyboardButton]] -- ^ Array of button rows, each represented by an Array of KeyboardButton objects.
-  , replyKeyboardMarkupIsPersistent      :: Maybe Bool         -- ^ Requests clients to always show the keyboard when the regular keyboard is hidden. Defaults to 'False', in which case the custom keyboard can be hidden and opened with a keyboard icon.
-  , replyKeyboardMarkupResizeKeyboard     :: Maybe Bool         -- ^ Requests clients to resize the keyboard vertically for optimal fit (e.g., make the keyboard smaller if there are just two rows of buttons). Defaults to false, in which case the custom keyboard is always of the same height as the app's standard keyboard.
-  , replyKeyboardMarkupOneTimeKeyboard    :: Maybe Bool         -- ^ Requests clients to hide the keyboard as soon as it's been used. The keyboard will still be available, but clients will automatically display the usual letter-keyboard in the chat – the user can press a special button in the input field to see the custom keyboard again. Defaults to false.
-  , replyKeyboardMarkupInputFieldSelector :: Maybe Text         -- ^ The placeholder to be shown in the input field when the keyboard is active; 1-64 characters.
-  , replyKeyboardMarkupSelective          :: Maybe Bool         -- ^ Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
-    --
-    -- Example: A user requests to change the bot's language, bot replies to the request with a keyboard to select the new language. Other users in the group don't see the keyboard.
-  }
-  deriving (Generic, Show)
-
--- ** 'KeyboardButtonRequestUser'
-
--- | This object defines the criteria used to request a suitable user. The identifier of the selected user will be shared with the bot when the corresponding button is pressed.
-data KeyboardButtonRequestUser = KeyboardButtonRequestUser
-  { keyboardButtonRequestUserRequestId :: RequestId -- ^ Signed 32-bit identifier of the request, which will be received back in the 'UserShared' object. Must be unique within the message
-  , keyboardButtonRequestUserUserIsBot :: Maybe Bool -- ^ Pass 'True' to request a bot, pass 'False' to request a regular user. If not specified, no additional restrictions are applied.
-  , keyboardButtonRequestUserUserIsPremium :: Maybe Bool -- ^ Pass 'True' to request a premium user, pass 'False' to request a non-premium user. If not specified, no additional restrictions are applied.
-  }
-  deriving (Generic, Show)
-
--- ** 'KeyboardButtonRequestChat'
-
--- | This object defines the criteria used to request a suitable chat. The identifier of the selected chat will be shared with the bot when the corresponding button is pressed.
-data KeyboardButtonRequestChat = KeyboardButtonRequestChat
-  { keyboardButtonRequestChatRequestId :: RequestId -- ^ Signed 32-bit identifier of the request, which will be received back in the 'ChatShared' object. Must be unique within the message
-  , keyboardButtonRequestChatChatIsChannel :: Bool -- ^ Pass 'True' to request a channel chat, pass 'False' to request a group or a supergroup chat. 
-  , keyboardButtonRequestChatChatIsForum :: Maybe Bool -- ^ Pass 'True' to request a forum supergroup, pass 'False' to request a non-forum chat. If not specified, no additional restrictions are applied.
-  , keyboardButtonRequestChatChatHasUsername :: Maybe Bool -- ^ Pass 'True' to request a supergroup or a channel with a username, pass 'False' to request a chat without a username. If not specified, no additional restrictions are applied.
-  , keyboardButtonRequestChatChatIsCreated :: Maybe Bool -- ^ Pass 'True' to request a chat owned by the user. Otherwise, no additional restrictions are applied.
-  , keyboardButtonRequestChatUserAdministratorRights :: Maybe ChatAdministratorRights -- ^ A JSON-serialized object listing the required administrator rights of the user in the chat. The rights must be a superset of @bot_administrator_rights@. If not specified, no additional restrictions are applied.
-  , keyboardButtonRequestChatBotAdministratorRights :: Maybe ChatAdministratorRights -- ^ A JSON-serialized object listing the required administrator rights of the bot in the chat. The rights must be a subset of @user_administrator_rights@. If not specified, no additional restrictions are applied.
-  , keyboardButtonRequestChatBotIsMember :: Maybe Bool -- ^ Pass 'True' to request a chat with the bot as a member. Otherwise, no additional restrictions are applied.
-  }
-  deriving (Generic, Show)
-
--- ** 'KeyboardButton'
-
-newtype WebAppInfo = WebAppInfo { webAppInfoUrl :: Text }
-  deriving (Generic, Show)
-
--- | This object represents one button of the reply keyboard.
--- For simple text buttons String can be used instead of this object
--- to specify text of the button. Optional fields are mutually exclusive.
-data KeyboardButton = KeyboardButton
-  { keyboardButtonText            :: Text       -- ^ Text of the button. If none of the optional fields are used, it will be sent as a message when the button is pressed.
-  , keyboardButtonRequestUser     :: Maybe KeyboardButtonRequestUser -- ^ If specified, pressing the button will open a list of suitable users. Tapping on any user will send their identifier to the bot in a “user_shared” service message. Available in private chats only.
-  , keyboardButtonRequestChat     :: Maybe KeyboardButtonRequestChat -- ^ If specified, pressing the button will open a list of suitable chats. Tapping on a chat will send its identifier to the bot in a “chat_shared” service message. Available in private chats only.
-  , keyboardButtonRequestContact  :: Maybe Bool -- ^ If 'True', the user's phone number will be sent as a contact when the button is pressed. Available in private chats only.
-  , keyboardButtonRequestLocation :: Maybe Bool -- ^ If 'True', the user's current location will be sent when the button is pressed. Available in private chats only.
-  , keyboardButtonRequestPoll     :: Maybe PollType -- ^ If specified, the user will be asked to create a poll and send it to the bot when the button is pressed. Available in private chats only.
-  , keyboardButtonWebApp          :: Maybe WebAppInfo -- ^ If specified, the described Web App will be launched when the button is pressed. The Web App will be able to send a “web_app_data” service message. Available in private chats only.
-  }
-  deriving (Generic, Show)
-
-instance IsString KeyboardButton where
-  fromString s = KeyboardButton (fromString s) Nothing Nothing Nothing Nothing Nothing Nothing
-
--- ** 'MenuButton'
-
--- | This object describes the bot's menu button in a private chat.
--- If a menu button other than @MenuButtonDefault@ is set for a private chat, then it is applied in the chat. Otherwise the default menu button is applied. By default, the menu button opens the list of bot commands.
-data MenuButton
-  = MenuButtonCommands -- ^ Represents a menu button, which opens the bot's list of commands.
-  | MenuButtonWebApp -- ^ Represents a menu button, which launches a Web App.
-      { menuButtonWebAppText :: Text
-      , menuButtonWebAppWebApp :: WebAppInfo
-      } 
-  | MenuButtonDefault -- ^ Describes that no specific value for the menu button was set.
-  deriving Generic
-
--- ** 'PollType'
-
-data PollType =
-  PollTypeQuiz | PollTypeRegular
-  deriving (Generic, Show)
-
-getPollType :: PollType -> Text
-getPollType PollTypeQuiz = "quiz"
-getPollType PollTypeRegular = "regular"
-
-instance ToJSON PollType where
-  toJSON = String . getPollType
-
-instance FromJSON PollType where parseJSON = gparseJSON
-
--- ** 'ReplyKeyboardRemove'
-
--- | Upon receiving a message with this object,
--- Telegram clients will remove the current custom keyboard
--- and display the default letter-keyboard.
---
--- By default, custom keyboards are displayed until a new keyboard is sent by a bot.
--- An exception is made for one-time keyboards that are hidden immediately after
--- the user presses a button (see 'ReplyKeyboardMarkup').
-data ReplyKeyboardRemove = ReplyKeyboardRemove
-  { replyKeyboardRemoveRemoveKeyboard :: Bool -- ^ Requests clients to remove the custom keyboard (user will not be able to summon this keyboard; if you want to hide the keyboard from sight but keep it accessible, use one_time_keyboard in ReplyKeyboardMarkup)
-  , replyKeyboardRemoveSelective      :: Maybe Bool -- ^ Use this parameter if you want to remove the keyboard for specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
-  --
-  -- Example: A user votes in a poll, bot returns confirmation message in reply to the vote and removes the keyboard for that user, while still showing the keyboard with poll options to users who haven't voted yet.
-  }
-  deriving (Generic, Show)
-
--- ** 'InlineKeyboardMarkup'
-
--- | This object represents an inline keyboard that appears
--- right next to the message it belongs to.
-data InlineKeyboardMarkup = InlineKeyboardMarkup
-  { inlineKeyboardMarkupInlineKeyboard :: [[InlineKeyboardButton]] -- ^ Array of button rows, each represented by an Array of InlineKeyboardButton objects
-  }
-  deriving (Generic, Show)
--- ^ 
--- **Note**: This will only work in Telegram versions released after 9 April, 2016. Older clients will display unsupported message.
-
--- ** 'InlineKeyboardButton'
-
--- | This object represents one button of an inline keyboard. You must use exactly one of the optional fields.
-data InlineKeyboardButton = InlineKeyboardButton
-  { inlineKeyboardButtonText              :: Text -- ^ Label text on the button
-  , inlineKeyboardButtonUrl               :: Maybe Text -- ^ HTTP url to be opened when button is pressed
-  , inlineKeyboardButtonCallbackData      :: Maybe Text -- ^ Data to be sent in a callback query to the bot when button is pressed, 1-64 bytes
-  , inlineKeyboardButtonWebApp            :: Maybe WebAppInfo -- ^ Description of the Web App that will be launched when the user presses the button. The Web App will be able to send an arbitrary message on behalf of the user using the method @answerWebAppQuery@. Available only in private chats between a user and the bot.
-  , inlineKeyboardButtonSwitchInlineQuery :: Maybe Text -- ^ If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot‘s username and the specified inline query in the input field. Can be empty, in which case just the bot’s username will be inserted.
-  , inlineKeyboardButtonSwitchInlineQueryCurrentChat :: Maybe Text -- ^ If set, pressing the button will insert the bot‘s username and the specified inline query in the current chat's input field. Can be empty, in which case only the bot’s username will be inserted.
-
-  , inlineKeyboardButtonCallbackGame      :: Maybe CallbackGame -- ^ Description of the game that will be launched when the user presses the button.
-  , inlineKeyboardButtonPay               :: Maybe Bool -- ^ Specify True, to send a Pay button.
-  }
-  deriving (Generic, Show)
-
-labeledInlineKeyboardButton :: Text -> InlineKeyboardButton
-labeledInlineKeyboardButton label = InlineKeyboardButton label Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-
--- ** 'LoginUrl'
-
--- | This object represents a parameter of the inline keyboard button used to automatically authorize a user. Serves as a great replacement for the Telegram Login Widget when the user is coming from Telegram. All the user needs to do is tap/click a button and confirm that they want to log in:
---
--- https://core.telegram.org/file/811140015/1734/8VZFkwWXalM.97872/6127fa62d8a0bf2b3c
---
--- Telegram apps support these buttons as of version 5.7.
-data LoginUrl = LoginUrl
-  { loginUrlUrl                :: Text       -- ^ An HTTP URL to be opened with user authorization data added to the query string when the button is pressed. If the user refuses to provide authorization data, the original URL without information about the user will be opened. The data added is the same as described in Receiving authorization data.
-  --
-  -- **NOTE**: You **must** always check the hash of the received data to verify the authentication and the integrity of the data as described in Checking authorization.
-  , loginUrlForwardText        :: Maybe Text -- ^ New text of the button in forwarded messages.
-  , loginUrlBotUsername        :: Maybe Text -- ^ Username of a bot, which will be used for user authorization. See Setting up a bot for more details. If not specified, the current bot's username will be assumed. The url's domain must be the same as the domain linked with the bot. See Linking your domain to the bot for more details.
-  , loginUrlRequestWriteAccess :: Maybe Bool -- ^ Pass 'True' to request the permission for your bot to send messages to the user.
-  }
-  deriving (Generic, Show)
-
--- ** 'CallbackQuery'
-
--- | This object represents an incoming callback query from a callback button
--- in an inline keyboard. If the button that originated the query was attached
--- to a message sent by the bot, the field message will be present.
--- If the button was attached to a message sent via the bot (in inline mode),
--- the field @inline_message_id@ will be present.
--- Exactly one of the fields data or game_short_name will be present.
-data CallbackQuery = CallbackQuery
-  { callbackQueryId              :: CallbackQueryId -- ^ Unique identifier for this query
-  , callbackQueryFrom            :: User -- ^ Sender
-  , callbackQueryMessage         :: Maybe Message -- ^ Message with the callback button that originated the query. Note that message content and message date will not be available if the message is too old
-  , callbackQueryInlineMessageId :: Maybe MessageId -- ^ Identifier of the message sent via the bot in inline mode, that originated the query.
-  , callbackQueryChatInstance    :: Text -- ^ Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent. Useful for high scores in games.
-  , callbackQueryData            :: Maybe Text -- ^ Data associated with the callback button. Be aware that a bad client can send arbitrary data in this field.
-  , callbackQueryGameShortName   :: Maybe Text -- ^ Short name of a Game to be returned, serves as the unique identifier for the game
-  }
-  deriving (Generic, Show)
-
-newtype CallbackQueryId = CallbackQueryId Text
-  deriving (Eq, Show, Generic, ToJSON, FromJSON)
-
--- ** 'ForceReply'
-
--- | Upon receiving a message with this object,
--- Telegram clients will display a reply interface to the user
--- (act as if the user has selected the bot‘s message and tapped ’Reply').
--- This can be extremely useful if you want to create user-friendly
--- step-by-step interfaces without having to sacrifice privacy mode.
-data ForceReply = ForceReply
-  { forceReplyForceReply            :: Bool       -- ^ Shows reply interface to the user, as if they manually selected the bot‘s message and tapped ’Reply'
-  , forceReplyInputFieldPlaceholder :: Maybe Text -- ^ The placeholder to be shown in the input field when the reply is active; 1-64 characters.
-  , forceReplySelective             :: Maybe Bool -- ^ Use this parameter if you want to force reply from specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
-  }
-  deriving (Generic, Show)
-
--- ** Chat photo
-
--- | Chat photo. Returned only in getChat.
-data ChatPhoto = ChatPhoto
-  { chatPhotoSmallFileId       :: FileId -- ^ Unique file identifier of small (160x160) chat photo. This file_id can be used only for photo download.
-  , chatPhotoSmallFileUniqueId :: FileId -- ^ Unique file identifier of small (160x160) chat photo, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , chatPhotoBigFileId         :: FileId -- ^ Unique file identifier of big (640x640) chat photo. This file_id can be used only for photo download.
-  , chatPhotoBigFileUniqueId   :: FileId -- ^ Unique file identifier of big (640x640) chat photo, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  }
-  deriving (Generic, Show)
-
--- ** 'ChatInviteLink'
-
--- | Represents an invite link for a chat.
-data ChatInviteLink = ChatInviteLink
-  { chatInviteLinkInviteLink              :: Text            -- ^ The invite link. If the link was created by another chat administrator, then the second part of the link will be replaced with “…”.
-  , chatInviteLinkCreator                 :: User            -- ^ Creator of the link.
-  , chatInviteLinkCreatesJoinRequest      :: Bool            -- ^ 'True', if users joining the chat via the link need to be approved by chat administrators.
-  , chatInviteLinkIsPrimary               :: Bool            -- ^ 'True', if the link is primary.
-  , chatInviteLinkIsRevoked               :: Bool            -- ^ 'True', if the link is revoked.
-  , chatInviteLinkName                    :: Maybe Text      -- ^ Invite link name.
-  , chatInviteLinkExpireDate              :: Maybe POSIXTime -- ^ Point in time (Unix timestamp) when the link will expire or has been expired.
-  , chatInviteLinkMemberLimit             :: Maybe Int     -- ^ Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999.
-  , chatInviteLinkPendingJoinRequestCount :: Maybe Int     -- ^ Number of pending join requests created using this link.
-  }
-  deriving (Generic, Show)
-
--- ** 'ChatAdministratorRights'
-
--- | Represents the rights of an administrator in a chat.
-data ChatAdministratorRights = ChatAdministratorRights
-  { chatAdministratorRightsIsAnonymous         :: Bool -- ^ 'True', if the user's presence in the chat is hidden.
-  , chatAdministratorRightsCanManageChat       :: Bool -- ^ 'True', if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege.
-  , chatAdministratorRightsCanDeleteMessages   :: Bool -- ^ 'True', if the administrator can delete messages of other users.
-  , chatAdministratorRightsCanManageVideoChats :: Bool -- ^ 'True', if the administrator can manage video chats.
-  , chatAdministratorRightsCanRestrictMembers  :: Bool -- ^ 'True', if the administrator can restrict, ban or unban chat members.
-  , chatAdministratorRightsCanPromoteMembers   :: Bool -- ^ 'True', if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user).
-  , chatAdministratorRightsCanChangeInfo       :: Bool -- ^ 'True', if the user is allowed to change the chat title, photo and other settings.
-  , chatAdministratorRightsCanInviteUsers      :: Bool -- ^ 'True', if the user is allowed to invite new users to the chat.
-  , chatAdministratorRightsCanPostMessages     :: Maybe Bool -- ^ 'True', if the administrator can post in the channel; channels only.
-  , chatAdministratorRightsCanEditMessages     :: Maybe Bool -- ^ 'True', if the administrator can edit messages of other users and can pin messages; channels only.
-  , chatAdministratorRightsCanPinMessages      :: Maybe Bool -- ^ 'True', if the user is allowed to pin messages; groups and supergroups only
-  , chatAdministratorRightsCanManageTopics     :: Maybe Bool -- ^ 'True', if the user is allowed to create, rename, close, and reopen forum topics; supergroups only.
-  }
-  deriving (Generic, Show)
-
--- ** 'ChatMember'
-
--- | This object contains information about one member of a chat.
-data ChatMember = ChatMember
-  { chatMemberUser                  :: User -- ^ Information about the user
-  , chatMemberStatus                :: Text -- ^ The member's status in the chat. Can be “owner”, “administrator”, “member”, “restricted”, “left” or “banned”.
-
-  -- banned, restricted
-  , chatMemberUntilDate             :: Maybe POSIXTime -- ^ Restictred and banned only. Date when restrictions will be lifted for this user, unix time.
-
-  -- owner, administrator
-  , chatMemberIsAnonymous           :: Maybe Bool -- ^ Owners and administrators only. 'True', if the user's presence in the chat is hidden.
-  , chatMemberCustomTitle           :: Maybe Text -- ^ Owners and administrators only. Custom title for this user.
-
-  -- administrator
-  , chatMemberCanBeEdited           :: Maybe Bool -- ^ Administrators only. 'True', if the bot is allowed to edit administrator privileges of that user
-  , chatMemberCanManageChat         :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege.
-  , chatMemberCanDeleteMessages     :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can delete messages of other users.
-  , chatMemberCanManageVideoChats   :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can manage video (previously, voice) chats.
-  , chatMemberCanRestrictMembers    :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can restrict, ban or unban chat members.
-  , chatMemberCanPromoteMembers     :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user).
-  , chatMemberCanChangeInfo         :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can change the chat title, photo and other settings.
-  , chatMemberCanPostMessages       :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can post in the channel, channels only.
-  , chatMemberCanEditMessages       :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can edit messages of other users and can pin messages, channels only.
-
-  -- administrator, restricted
-  , chatMemberCanInviteUsers        :: Maybe Bool -- ^ Administrators and restricted only. 'True', if the administrator can invite new users to the chat.
-  , chatMemberCanPinMessages        :: Maybe Bool -- ^ Administrators and restricted only. 'True', if the administrator can pin messages, supergroups only.
-  , chatMemberCanManageTopics       :: Maybe Bool -- ^ Administrators and restricted only. 'True', if the user is allowed to create, rename, close, and reopen forum topics; supergroups only.
-
-  -- restricted
-  , chatMemberIsMember              :: Maybe Bool -- ^ Restricted only. 'True', if the user is a member of the chat at the moment of the request.
-  , chatMemberCanSendMessages       :: Maybe Bool -- ^ Restricted only. 'True', if the user can send text messages, contacts, locations and venues.
-  , chatMemberCanSendAudios         :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send audios.
-  , chatMemberCanSendDocuments      :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send documents.
-  , chatMemberCanSendPhotos         :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send photos.
-  , chatMemberCanSendVideos         :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send videos.
-  , chatMemberCanSendVideoNotes     :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send video notes.
-  , chatMemberCanSendVoiceNotes     :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send voice notes.
-  , chatMemberCanSendPolls          :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send polls.
-  , chatMemberCanSendOtherMessages  :: Maybe Bool -- ^ Restricted only. 'True', if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages.
-  , chatMemberCanAddWebPagePreviews :: Maybe Bool -- ^ Restricted only. 'True', if user may add web page previews to his messages, implies can_send_media_messages.
-  }
-  deriving (Generic, Show)
-
--- ** 'ChatMemberUpdated'
-
--- | This object represents changes in the status of a chat member.
-data ChatMemberUpdated = ChatMemberUpdated
-  { chatMemberUpdatedChat          :: Chat                 -- ^ Chat the user belongs to.
-  , chatMemberUpdatedFrom          :: User                 -- ^ Performer of the action, which resulted in the change.
-  , chatMemberUpdatedDate          :: POSIXTime            -- ^ Date the change was done in Unix time.
-  , chatMemberUpdatedOldChatMember :: ChatMember           -- ^ Previous information about the chat member.
-  , chatMemberUpdatedNewChatMember :: ChatMember           -- ^ New information about the chat member.
-  , chatMemberUpdatedInviteLink    :: Maybe ChatInviteLink -- ^ Chat invite link, which was used by the user to join the chat; for joining by invite link events only.
-  }
-  deriving (Generic, Show)
-
--- ** 'ChatJoinRequest'
-
--- | Represents a join request sent to a chat.
-data ChatJoinRequest = ChatJoinRequest
-  { chatJoinRequestChat       :: Chat                 -- ^ Chat to which the request was sent.
-  , chatJoinRequestFrom       :: User                 -- ^ User that sent the join request.
-  , chatJoinRequestUserChatId :: ChatId               -- ^ Identifier of a private chat with the user who sent the join request. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot can use this identifier for 24 hours to send messages until the join request is processed, assuming no other administrator contacted the user.
-  , chatJoinRequestDate       :: POSIXTime            -- ^ Date the request was sent in Unix time.
-  , chatJoinRequestBio        :: Maybe Text           -- ^ Bio of the user.
-  , chatJoinRequestInviteLink :: Maybe ChatInviteLink -- ^ Chat invite link that was used by the user to send the join request.
-  }
-  deriving (Generic, Show)
-
--- ** 'ChatPermissions'
-
--- | Describes actions that a non-administrator user is allowed to take in a chat.
-data ChatPermissions = ChatPermissions
-  { chatPermissionsCanSendMessages :: Maybe Bool       -- ^ 'True', if the user is allowed to send text messages, contacts, locations and venues.
-  , chatPermissionsCanSendAudios     :: Maybe Bool     -- ^ 'True', if the user is allowed to send audios.
-  , chatPermissionsCanSendDocuments  :: Maybe Bool     -- ^ 'True', if the user is allowed to send documents.
-  , chatPermissionsCanSendPhotos     :: Maybe Bool     -- ^ 'True', if the user is allowed to send photos.
-  , chatPermissionsCanSendVideos     :: Maybe Bool     -- ^ 'True', if the user is allowed to send videos.
-  , chatPermissionsCanSendVideoNotes :: Maybe Bool     -- ^ 'True', if the user is allowed to send video notes.
-  , chatPermissionsCanSendVoiceNotes :: Maybe Bool     -- ^ 'True', if the user is allowed to send voice notes.
-  , chatPermissionsCanSendPolls :: Maybe Bool          -- ^ 'True', if the user is allowed to send polls, implies can_send_messages.
-  , chatPermissionsCanSendOtherMessages :: Maybe Bool  -- ^ 'True', if the user is allowed to send animations, games, stickers and use inline bots, implies can_send_media_messages.
-  , chatPermissionsCanAddWebPagePreviews :: Maybe Bool -- ^ 'True', if the user is allowed to add web page previews to their messages, implies can_send_media_messages.
-  , chatPermissionsCanChangeInfo :: Maybe Bool         -- ^ 'True', if the user is allowed to change the chat title, photo and other settings. Ignored in public supergroups
-  , chatPermissionsCanInviteUsers :: Maybe Bool        -- ^ 'True', if the user is allowed to invite new users to the chat.
-  , chatPermissionsCanPinMessages :: Maybe Bool        -- ^ 'True', if the user is allowed to pin messages. Ignored in public supergroups.
-  , chatPermissionsCanManageTopics :: Maybe Bool       -- ^ 'True', if the user is allowed to create forum topics. If omitted defaults to the value of can_pin_messages.
-  }
-  deriving (Generic, Show)
-
--- ** 'ChatLocation'
-
--- | Represents a location to which a chat is connected.
-data ChatLocation = ChatLocation
-  { chatLocationLocation :: Location -- ^ The location to which the supergroup is connected. Can't be a live location..
-  , chatLocationAddress :: Text      -- ^ Location address; 1-64 characters, as defined by the chat owner.
-  }
-  deriving (Generic, Show)
-
--- ** 'ResponseParameters'
-
--- | Contains information about why a request was unsuccessful.
-data ResponseParameters = ResponseParameters
-  { responseParametersMigrateToChatId :: Maybe ChatId -- ^ The group has been migrated to a supergroup with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
-  , responseParametersRetryAfter      :: Maybe Seconds -- ^ In case of exceeding flood control, the number of seconds left to wait before the request can be repeated
-  }
-  deriving (Show, Generic)
 
 -- * Stickers
 
 -- | The following methods and objects allow your bot to handle stickers and sticker sets.
 
--- ** 'Sticker'
-
--- | This object represents a sticker.
-data Sticker = Sticker
-  { stickerFileId       :: FileId             -- ^ Identifier for this file, which can be used to download or reuse the file.
-  , stickerFileUniqueId :: FileId             -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , stickerWidth        :: Int              -- ^ Sticker width.
-  , stickerHeight       :: Int              -- ^ Sticker height.
-  , stickerIsAnimated   :: Bool               -- ^ 'True', if the sticker is animated.
-  , stickerIsVideo      :: Bool               -- ^ 'True', if the sticker is a video sticker.
-  , stickerThumb        :: Maybe PhotoSize    -- ^ Sticker thumbnail in the .WEBP or .JPG format.
-  , stickerEmoji        :: Maybe Text         -- ^ Emoji associated with the sticker.
-  , stickerSetName      :: Maybe Text         -- ^ Name of the sticker set to which the sticker belongs.
-  , stickerPremiumAnimation :: Maybe File    -- ^ For premium regular stickers, premium animation for the sticker.
-  , stickerMaskPosition :: Maybe MaskPosition -- ^ For mask stickers, the position where the mask should be placed.
-  , stickerCustomEmojiId :: Maybe Text        -- ^ For custom emoji stickers, unique identifier of the custom emoji.
-  , stickerFileSize     :: Maybe Integer      -- ^ File size in bytes.
-  }
-  deriving (Generic, Show)
-
--- ** 'StickerSet'
-
--- | This object represents a sticker set.
-data StickerSet = StickerSet
-  { stickerSetName          :: Text            -- ^ Sticker set name.
-  , stickerSetTitle         :: Text            -- ^ Sticker set title.
-  , stickerSetType          :: StickerSetType  -- ^ Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”.
-  , stickerSetIsAnimated    :: Bool            -- ^ 'True', if the sticker set contains animated stickers.
-  , stickerSetIsVideo       :: Bool            -- ^ 'True', if the sticker is a video sticker.
-  , stickerSetContainsMasks :: Maybe Bool      -- ^ True, if the sticker set contains masks.
-  , stickerSetStickers      :: [Sticker]       -- ^ List of all set stickers.
-  , stickerSetThumb         :: Maybe PhotoSize -- ^ Sticker set thumbnail in the .WEBP or .TGS format.
-  }
-  deriving (Generic, Show)
-
--- | Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”.
-data StickerSetType
-  = StickerSetTypeRegular
-  | StickerSetTypeMask
-  | StickerSetTypeCustomEmoji
-  deriving (Eq, Show, Generic)
-
--- ** 'MaskPosition'
-
--- | This object describes the position on faces where a mask should be placed by default.
-data MaskPosition = MaskPosition
-  { maskPositionPoint  :: Text  -- ^ The part of the face relative to which the mask should be placed. One of “forehead”, “eyes”, “mouth”, or “chin”.
-  , maskPositionXShift :: Float -- ^ Shift by X-axis measured in widths of the mask scaled to the face size, from left to right. For example, choosing -1.0 will place mask just to the left of the default mask position.
-  , maskPositionYShift :: Float -- ^ Shift by Y-axis measured in heights of the mask scaled to the face size, from top to bottom. For example, 1.0 will place the mask just below the default mask position.
-  , maskPositionScale  :: Float -- ^ Mask scaling coefficient. For example, 2.0 means double size.
-  }
-  deriving (Generic, Show)
 
 -- * Payments
-
--- ** 'LabeledPrice'
-
--- | This object represents a portion of the price for goods or services.
-data LabeledPrice = LabelPrice
-  { labeledPriceLabel  :: Text  -- ^ Portion label.
-  , labeledPriceAmount :: Int -- ^ Price of the product in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
-  }
-  deriving (Generic, Show)
-
--- ** 'Invoice'
-
--- | This object contains basic information about an invoice.
-data Invoice = Invoice
-  { invoiceTitle          :: Text  -- ^ Product name.
-  , invoiceDescription    :: Text  -- ^ Product description.
-  , invoiceStartParameter :: Text  -- ^ Unique bot deep-linking parameter that can be used to generate this invoice.
-  , invoiceCurrency       :: Text  -- ^ Three-letter ISO 4217 currency code.
-  , invoiceTotalAmount    :: Int -- ^ Total price in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
-  }
-  deriving (Generic, Show)
-
--- ** 'ShippingAddress'
-
--- | This object represents a shipping address.
-data ShippingAddress = ShippingAddress
-  { shippingAddressCountryCode :: Text -- ^ ISO 3166-1 alpha-2 country code.
-  , shippingAddressState       :: Text -- ^ State, if applicable.
-  , shippingAddressCity        :: Text -- ^ City.
-  , shippingAddressStreetLine1 :: Text -- ^ First line for the address.
-  , shippingAddressStreetLine2 :: Text -- ^ Second line for the address.
-  , shippingAddressPostCode    :: Text -- ^ Address post code.
-  }
-  deriving (Generic, Show)
-
--- ** 'OrderInfo'
-
--- | This object represents information about an order.
-data OrderInfo = OrderInfo
-  { orderInfoName            :: Maybe Text            -- ^ User name.
-  , orderInfoPhoneNumber     :: Maybe Text            -- ^ User's phone number.
-  , orderInfoEmail           :: Maybe Text            -- ^ User email.
-  , orderInfoShippingAddress :: Maybe ShippingAddress -- ^ User shipping address.
-  }
-  deriving (Generic, Show)
-
--- ** 'ShippingOption'
-
--- | This object represents one shipping option.
-data ShippingOption = ShippingOption
-  { shippingOptionId    :: ShippingOptionId -- ^ Shipping option identifier.
-  , shippingOptionTitle :: Text             -- ^ Option title.
-  , shippingOptionPrice :: [LabeledPrice]   -- ^ List of price portions.
-  }
-  deriving (Generic, Show)
-
-newtype ShippingOptionId = ShippingOptionId Text
-  deriving (Eq, Show, Generic, ToJSON, FromJSON)
-
--- ** 'SuccessfulPayment'
-
--- | This object contains basic information about a successful payment.
-data SuccessfulPayment = SuccessfulPayment
-  { successfulPaymentCurrency                :: Text                   -- ^ Three-letter ISO 4217 currency code.
-  , successfulPaymentTotalAmount             :: Int                  -- ^ Total price in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
-  , successfulPaymentInvoicePayload          :: Text                   -- ^ Bot specified invoice payload.
-  , successfulPaymentShippingOptionId        :: Maybe ShippingOptionId -- ^ Identifier of the shipping option chosen by the user.
-  , successfulPaymentOrderInfo               :: Maybe OrderInfo        -- ^ Order info provided by the user.
-  , successfulPaymentTelegramPaymentChargeId :: Text                   -- ^ Telegram payment identifier.
-  , successfulPaymentProviderPaymentChargeId :: Text                   -- ^ Provider payment identifier.
-  }
-  deriving (Generic, Show)
-
--- ** 'ShippingQuery'
-
--- | This object contains information about an incoming shipping query.
-data ShippingQuery = ShippingQuery
-  { shippingQueryId              :: Text            -- ^ Unique query identifier.
-  , shippingQueryFrom            :: User            -- ^ User who sent the query.
-  , shippingQueryInvoicePayload  :: Text            -- ^ Bot specified invoice payload.
-  , shippingQueryShippingAddress :: ShippingAddress -- ^ User specified shipping address.
-  }
-  deriving (Generic, Show)
-
--- ** 'PreCheckoutQuery'
-
--- | This object contains information about an incoming pre-checkout query.
-data PreCheckoutQuery = PreCheckoutQuery
-  { preCheckoutQueryId               :: Text                   -- ^ Unique query identifier.
-  , preCheckoutQueryFrom             :: User                   -- ^ User who sent the query.
-  , preCheckoutQueryCurrency         :: Text                   -- ^ Three-letter ISO 4217 currency code
-  , preCheckoutQueryTotalAmount      :: Int                  -- ^ Total price in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
-  , preCheckoutQueryInvoicePayload   :: Text                   -- ^ Bot specified invoice payload
-  , preCheckoutQueryShippingOptionId :: Maybe ShippingOptionId -- ^ Identifier of the shipping option chosen by the user.
-  , preCheckoutQueryOrderInfo        :: Maybe OrderInfo        -- ^ Order info provided by the user.
-  }
-  deriving (Generic, Show)
 
 -- * Telegram Passport
 
 -- | Telegram Passport is a unified authorization method for services that require personal identification. Users can upload their documents once, then instantly share their data with services that require real-world ID (finance, ICOs, etc.). Please see the manual for details.
-
--- ** 'PassportData'
-
--- | Contains information about Telegram Passport data shared with the bot by the user.
-data PassportData = PassportData
-  { passportDataData        :: [EncryptedPassportElement] -- ^ Array with information about documents and other Telegram Passport elements that was shared with the bot.
-  , passportDataCredentials :: EncryptedCredentials       -- ^ Encrypted credentials required to decrypt the data.
-  }
-  deriving (Generic, Show)
-
--- ** 'PassportFile'
-
--- | This object represents a file uploaded to Telegram Passport. Currently all Telegram Passport files are in JPEG format when decrypted and don't exceed 10MB.
-data PassportFile = PassportFile
-  { passportFileFileId       :: FileId    -- ^ Identifier for this file, which can be used to download or reuse the file.
-  , passportFileFileUniqueId :: FileId    -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  , passportFileFileSize     :: Int     -- ^ File size in bytes.
-  , passportFileFileDate     :: POSIXTime -- ^ Unix time when the file was uploaded.
-  }
-  deriving (Generic, Show)
-
--- ** 'EncryptedPassportElement'
-
--- | Contains information about documents or other Telegram Passport elements shared with the bot by the user.
-data EncryptedPassportElement = EncryptedPassportElement
-  { encryptedPassportElementType        :: PassportElementType  -- ^ One of “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport”, “address”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration”, “temporary_registration”, “phone_number”, “email”.
-  , encryptedPassportElementData        :: Maybe Text           -- ^ Base64-encoded encrypted Telegram Passport element data provided by the user, available for “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport” and “address” types. Can be decrypted and verified using the accompanying 'EncryptedCredentials'.
-  , encryptedPassportElementPhoneNumber :: Maybe Text           -- ^ User's verified phone number, available only for “phone_number” type.
-  , encryptedPassportElementEmail       :: Maybe Text           -- ^ User's verified email address, available only for “email” type.
-  , encryptedPassportElementFiles       :: Maybe [PassportFile] -- ^ Array of encrypted files with documents provided by the user, available for “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration” and “temporary_registration” types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
-  , encryptedPassportElementFrontSide   :: Maybe PassportFile   -- ^ Encrypted file with the front side of the document, provided by the user. Available for “passport”, “driver_license”, “identity_card” and “internal_passport”. The file can be decrypted and verified using the accompanying EncryptedCredentials.
-  , encryptedPassportElementReverseSide :: Maybe PassportFile   -- ^ Encrypted file with the reverse side of the document, provided by the user. Available for “driver_license” and “identity_card”. The file can be decrypted and verified using the accompanying EncryptedCredentials.
-  , encryptedPassportElementSelfie      :: Maybe PassportFile   -- ^ Encrypted file with the selfie of the user holding a document, provided by the user; available for “passport”, “driver_license”, “identity_card” and “internal_passport”. The file can be decrypted and verified using the accompanying EncryptedCredentials.
-  , encryptedPassportElementTranslation :: Maybe [PassportFile] -- ^ Array of encrypted files with translated versions of documents provided by the user. Available if requested for “passport”, “driver_license”, “identity_card”, “internal_passport”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration” and “temporary_registration” types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
-  , encryptedPassportElementHash        :: Text                 -- ^ Base64-encoded element hash for using in 'PassportElementErrorUnspecified'.
-  } deriving (Generic, Show)
-
-
--- | One of “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport”, “address”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration”, “temporary_registration”, “phone_number”, “email”.
-data PassportElementType
-  = PassportElementTypePersonalDetails
-  | PassportElementTypePassport
-  | PassportElementTypeDriverLicense
-  | PassportElementTypeIdentityCard
-  | PassportElementTypeInternalPassport
-  | PassportElementTypeAddress
-  | PassportElementTypeUtilityBill
-  | PassportElementTypeBankStatement
-  | PassportElementTypeRentalAgreement
-  | PassportElementTypePassportRegistration
-  | PassportElementTypeTemporaryRegistration
-  | PassportElementTypePhoneNumber
-  | PassportElementTypeEmail
-  deriving (Generic, Show)
-
--- ** 'EncryptedCredentials'
-
--- | Contains data required for decrypting and authenticating EncryptedPassportElement. See the Telegram Passport Documentation for a complete description of the data decryption and authentication processes.
-data EncryptedCredentials = EncryptedCredentials
-  { encryptedCredentialsData   :: Text -- ^ Base64-encoded encrypted JSON-serialized data with unique user's payload, data hashes and secrets required for EncryptedPassportElement decryption and authentication.
-  , encryptedCredentialsHash   :: Text -- ^ Base64-encoded data hash for data authentication.
-  , encryptedCredentialsSecret :: Text -- ^ Base64-encoded secret, encrypted with the bot's public RSA key, required for data decryption
-  }
-  deriving (Generic, Show)
-
--- ** 'PassportElementError'
-
-data PassportErrorSource
-  = PassportErrorSourceData
-  | PassportErrorSourceFrontSide
-  | PassportErrorSourceReverseSide
-  | PassportErrorSourceSelfie
-  | PassportErrorSourceFile
-  | PassportErrorSourceFiles
-  | PassportErrorSourceTranslationFile
-  | PassportErrorSourceTranslationFiles
-  | PassportErrorSourceUnspecified
-  deriving (Generic, Show)
-
-data PassportElementError
-  = PassportElementError
-    { passportElementErroSource       :: PassportErrorSource -- ^ Error source, must be one of 'PassportErrorSource'.
-    , passportElementErrorType        :: PassportElementType -- ^ The section of the user's Telegram Passport which has the error, one of 'PassportElementType'.
-    , passportElementErrorName        :: Text                -- ^ Name of the data field which has the error.
-    , passportElementErrorHash        :: Maybe Text          -- ^ Base64-encoded data hash.
-    , passportElementErrorMessage     :: Text                -- ^ Error message.
-    , passportElementErrorFileHash    :: Maybe Text          -- ^ Base64-encoded hash of the file with the reverse side of the document.
-    , passportElementErrorFileHashes  :: Maybe [Text]        -- ^ List of base64-encoded file hashes.
-    , passportElementErrorElementHash :: Maybe Text          -- ^ Base64-encoded element hash.
-    }
-    deriving (Generic, Show)
 
 -- * Games
 
@@ -1226,383 +211,3 @@ data PassportElementError
 -- You can also add an extra sharing button for users to share their best score to different chats.
 -- For examples of what can be done using this new stuff, check the @gamebot and @gamee bots.
 
--- ** 'Game'
-
--- | This object represents a game. Use BotFather to create and edit games, their short names will act as unique identifiers.
-data Game = Game
-  { gameTitle        :: Text                  -- ^ Title of the game.
-  , gameDescription  :: Text                  -- ^ Description of the game.
-  , gamePhoto        :: [PhotoSize]           -- ^ Photo that will be displayed in the game message in chats.
-  , gameText         :: Maybe Text            -- ^ Brief description of the game or high scores included in the game message. Can be automatically edited to include current high scores for the game when the bot calls setGameScore, or manually edited using editMessageText. 0-4096 characters.
-  , gameTextEntities :: Maybe [MessageEntity] -- ^ Special entities that appear in text, such as usernames, URLs, bot commands, etc.
-  , gameAnimation    :: Maybe Animation       -- ^ Animation that will be displayed in the game message in chats. Upload via @BotFather@.
-  }
-  deriving (Generic, Show)
-
--- ** 'CallbackGame'
-
--- | A placeholder, currently holds no information. Use BotFather to set up your game.
-newtype CallbackGame = CallbackGame Object
-  deriving (Generic, Show)
-
--- ** 'GameHighScore'
-
--- | This object represents one row of the high scores table for a game.
-data GameHighScore = GameHighScore
-  { gameHighScorePosition :: Int -- ^ Position in high score table for the game.
-  , gameHighScoreUser     :: User  -- ^ User.
-  , gameHighScoreScore    :: Int -- ^ Score.
-  }
-  deriving (Generic, Show)
-
--- ** 'CopyMessageId'
-
--- | This object represents result of copyMessage request.
-data CopyMessageId = CopyMessageId
-  { copyMessageIdMessageId :: MessageId -- ^ the MessageId of the sent message.
-  }
-  deriving (Generic, Show)
-
-
--- | Unique identifier for the target chat
--- or username of the target channel (in the format @\@channelusername@).
-data SomeChatId
-  = SomeChatId ChatId       -- ^ Unique chat ID.
-  | SomeChatUsername Text   -- ^ Username of the target channel.
-  deriving (Generic)
-
-instance ToJSON   SomeChatId where toJSON = genericSomeToJSON
-instance FromJSON SomeChatId where parseJSON = genericSomeParseJSON
-
-instance ToHttpApiData SomeChatId where
-  toUrlPiece (SomeChatId chatid) = toUrlPiece chatid
-  toUrlPiece (SomeChatUsername name) = name
-  
--- | This object represents a forum topic.
-data ForumTopic = ForumTopic
-  { forumTopicMessageThreadId   :: MessageThreadId -- ^ Unique identifier of the forum topic
-  , forumTopicName              :: Text            -- ^ Name of the topic
-  , forumTopicIconColor         :: Integer         -- ^ Color of the topic icon in RGB format.
-  , forumTopicIconCustomEmojiId :: Maybe Text      -- ^ Unique identifier of the custom emoji shown as the topic icon.
-  }
-  deriving Generic
-
--- | This object represents a bot command.
-data BotCommand = BotCommand
-  { botCommandCommand :: Text -- ^ Text of the command; 1-32 characters. Can contain only lowercase English letters, digits and underscores.
-  , botCommandDescription :: Text -- ^ Description of the command; 1-256 characters.
-  }
-  deriving (Generic, Show)
-
-data BotCommandScope
-  = BotCommandScopeDefault -- ^ Represents the default scope of bot commands. Default commands are used if no commands with a narrower scope are specified for the user.
-  | BotCommandScopeAllPrivateChats -- ^ Represents the scope of bot commands, covering all private chats.
-  | BotCommandScopeAllGroupChats -- ^ Represents the scope of bot commands, covering all group and supergroup chats.
-  | BotCommandScopeAllChatAdministrators -- ^ Represents the scope of bot commands, covering all group and supergroup chat administrators.
-  | BotCommandScopeChat SomeChatId -- ^ Represents the scope of bot commands, covering a specific chat.
-  | BotCommandScopeChatAdministrators SomeChatId -- ^ Represents the scope of bot commands, covering all administrators of a specific group or supergroup chat.
-  | BotCommandScopeChatMember SomeChatId UserId -- ^ Represents the scope of bot commands, covering a specific member of a group or supergroup chat.
-
-addType :: Text -> [Pair] -> [Pair]
-addType name xs = ("type" .= name) : xs
-
-instance ToJSON BotCommandScope where
-  toJSON = \case
-    BotCommandScopeDefault ->
-      object $ addType "default" []
-    BotCommandScopeAllPrivateChats ->
-      object $ addType "all_private_chats" []
-    BotCommandScopeAllGroupChats ->
-      object $ addType "all_group_chats" []
-    BotCommandScopeAllChatAdministrators ->
-      object $ addType "all_chat_administrators" []
-    BotCommandScopeChat sci ->
-      object $ addType "chat" ["chat_id" .= sci]
-    BotCommandScopeChatAdministrators sci ->
-      object $ addType "chat_administrators" ["chat_id" .= sci]
-    BotCommandScopeChatMember sci ui ->
-      object $ addType "chat_member" ["chat_id" .= sci, "user_id" .= ui]
-
-instance FromJSON BotCommandScope where
-  parseJSON = withObject "BotCommandScope" \o ->
-    (o .: "type" :: Parser Text) >>= \case
-    "default" ->                pure BotCommandScopeDefault
-    "all_private_chats" ->      pure BotCommandScopeAllPrivateChats
-    "all_group_chats" ->        pure BotCommandScopeAllGroupChats
-    "all_chat_administrators"-> pure BotCommandScopeAllChatAdministrators
-    "chat" ->                        BotCommandScopeChat <$> o .: "chat_id"
-    "chat_administrators"->          BotCommandScopeChatAdministrators <$> o .: "chat_id"
-    "chat_member"->                  BotCommandScopeChatMember <$> o .: "chat_id" <*> o .: "user_id"
-    t -> fail $ Text.unpack ("Unknown type: " <> t)
-
-
--- | Generic fields for all InputMedia structures
-data InputMediaGeneric = InputMediaGeneric
-  { inputMediaGenericMedia :: InputFile -- ^ File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
-  , inputMediaGenericCaption :: Maybe Text -- ^ Caption of the photo to be sent, 0-1024 characters after entities parsing.
-  , inputMediaGenericParseMode :: Maybe Text -- ^ Mode for parsing entities in the photo caption. See formatting options <https:\/\/core.telegram.org\/bots\/api#formatting-options> for more details.
-  , inputMediaGenericCaptionEntities :: Maybe [MessageEntity] -- ^ List of special entities that appear in the caption, which can be specified instead of parse_mode.
-  }
-  deriving Generic
-
-data InputMediaGenericThumb = InputMediaGenericThumb
-  { inputMediaGenericGeneric :: InputMediaGeneric
-  , inputMediaGenericThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. 
-  }
-
-data InputMedia
-  = InputMediaPhoto -- ^ Represents a photo to be sent.
-    { inputMediaPhotoGeneric :: InputMediaGeneric
-    , inputMediaPhotoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
-    }
-  | InputMediaVideo -- ^ Represents a video to be sent.
-    { inputMediaVideoGeneric :: InputMediaGenericThumb
-    , inputMediaVideoWidth :: Maybe Integer -- ^ Video width
-    , inputMediaVideoHeight :: Maybe Integer -- ^ Video height
-    , inputMediaVideoDuration :: Maybe Integer -- ^ Video duration in seconds
-    , inputMediaVideoSupportsStreaming :: Maybe Bool -- ^ Pass 'True', if the uploaded video is suitable for streaming.
-    , inputMediaVideoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
-    }
-  | InputMediaAnimation -- ^ Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.
-    { inputMediaAnimationGeneric :: InputMediaGenericThumb
-    , inputMediaAnimationWidth :: Maybe Integer -- ^ Animation width
-    , inputMediaAnimationHeight :: Maybe Integer -- ^ Animation height
-    , inputMediaAnimationDuration :: Maybe Integer -- ^ Animation duration in seconds
-    , inputMediaAnimationHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
-    }
-  | InputMediaAudio -- ^ Represents an audio file to be treated as music to be sent.
-    { inputMediaAudioGeneric :: InputMediaGenericThumb
-    , inputMediaAudioDuration :: Maybe Integer -- ^ Duration of the audio in seconds
-    , inputMediaAudioPerformer :: Maybe Text -- ^ Performer of the audio
-    , inputMediaAudioTitle :: Maybe Text -- ^ Title of the audio
-    }
-  | InputMediaDocument -- ^ Represents a general file to be sent.
-    { inputMediaDocumentGeneric :: InputMediaGenericThumb
-    , inputMediaDocumentDisableContentTypeDetection :: Maybe Bool -- ^ Disables automatic server-side content type detection for files uploaded using multipart/form-data. Always True, if the document is sent as part of an album.
-    }
-
-foldMap deriveJSON'
-  [ ''User
-  , ''Chat
-  , ''Message
-  , ''MessageEntityType
-  , ''MessageEntity
-  , ''PhotoSize
-  , ''Audio
-  , ''Document
-  , ''StickerSetType
-  , ''Sticker
-  , ''Video
-  , ''Voice
-  , ''VideoNote
-  , ''Contact
-  , ''Location
-  , ''Venue
-  , ''UserProfilePhotos
-  , ''File
-  , ''ReplyKeyboardMarkup
-  , ''KeyboardButton
-  , ''KeyboardButtonRequestUser
-  , ''KeyboardButtonRequestChat
-  , ''ReplyKeyboardRemove
-  , ''InlineKeyboardMarkup
-  , ''InlineKeyboardButton
-  , ''CallbackQuery
-  , ''ForceReply
-  , ''ChatPhoto
-  , ''ChatMember
-  , ''ChatMemberUpdated
-  , ''ResponseParameters
-  , ''MaskPosition
-  , ''CallbackGame
-  , ''Animation
-  , ''Dice
-  , ''Game
-  , ''Poll
-  , ''PollAnswer
-  , ''ChatJoinRequest
-  , ''PollOption
-  , ''MessageAutoDeleteTimerChanged
-  , ''ForumTopicCreated
-  , ''ForumTopicEdited
-  , ''ForumTopicClosed
-  , ''ForumTopicReopened
-  , ''GeneralForumTopicHidden
-  , ''GeneralForumTopicUnhidden
-  , ''UserShared
-  , ''ChatShared
-  , ''WriteAccessAllowed
-  , ''Invoice
-  , ''SuccessfulPayment
-  , ''OrderInfo
-  , ''ShippingAddress
-  , ''PassportData
-  , ''EncryptedPassportElement
-  , ''PassportElementType
-  , ''PassportFile
-  , ''PassportElementError
-  , ''PassportErrorSource
-  , ''EncryptedCredentials
-  , ''ProximityAlertTriggered
-  , ''VideoChatScheduled
-  , ''VideoChatEnded
-  , ''VideoChatParticipantsInvited
-  , ''ChatPermissions
-  , ''ChatLocation
-  , ''StickerSet
-  , ''BotCommand
-  , ''ForumTopic
-  , ''ChatInviteLink
-  , ''LabeledPrice
-  , ''ShippingOption
-  , ''ShippingQuery
-  , ''PreCheckoutQuery
-  , ''WebAppData
-  , ''WebAppInfo
-  , ''ChatAdministratorRights
-  , ''CopyMessageId
-  ]
-
-instance ToJSON InputMediaGeneric where toJSON = gtoJSON
-
-instance ToHttpApiData PassportElementError where
-  toUrlPiece = TL.toStrict . encodeToLazyText
-
-instance ToHttpApiData [PassportElementError] where
-  toUrlPiece = TL.toStrict . encodeToLazyText
-
-instance ToMultipart Tmp InputMediaGeneric where
-  toMultipart InputMediaGeneric{..} = makeFile "media" inputMediaGenericMedia (MultipartData fields []) where
-    fields = catMaybes
-      [ inputMediaGenericCaption <&>
-        \t -> Input "caption" t
-      , inputMediaGenericParseMode <&>
-        \t -> Input "parse_mode" t
-      , inputMediaGenericCaptionEntities <&>
-        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
-      ]
-
-instance ToJSON InputMediaGenericThumb where
-  toJSON InputMediaGenericThumb{..}
-    = addJsonFields (toJSON inputMediaGenericGeneric)
-      ["thumb" .= inputMediaGenericThumb]
-
-instance ToMultipart Tmp InputMediaGenericThumb where
-  toMultipart = \case
-    InputMediaGenericThumb generic Nothing -> toMultipart generic
-    InputMediaGenericThumb generic (Just thumb) -> makeFile "thumb" thumb (toMultipart generic)
-
-instance ToJSON InputMedia where
-  toJSON = \case
-    InputMediaPhoto img spoiler ->
-      addJsonFields (toJSON img) (addType "photo" [ "has_spoiler" .= spoiler])
-    InputMediaVideo imgt width height duration streaming spoiler ->
-      addJsonFields (toJSON imgt)
-                (addType "video"
-                [ "width" .= width
-                , "height" .= height
-                , "duration" .= duration
-                , "support_streaming" .= streaming
-                , "has_spoiler" .= spoiler
-                ])
-    InputMediaAnimation imgt width height duration spoiler ->
-      addJsonFields (toJSON imgt)
-                (addType "animation"
-                [ "width" .= width
-                , "height" .= height
-                , "duration" .= duration
-                , "has_spoiler" .= spoiler
-                ])
-    InputMediaAudio imgt duration performer title ->
-      addJsonFields (toJSON imgt)
-                (addType "audio"
-                [ "duration" .= duration
-                , "performer" .= performer
-                , "title" .= title
-                ])
-    InputMediaDocument imgt dctd ->
-      addJsonFields (toJSON imgt)
-                (addType "document" ["disable_content_type_detection" .= dctd])
-
-
-
-instance ToMultipart Tmp InputMedia where
-  toMultipart = let
-    in \case
-    InputMediaPhoto img spoiler ->
-      addMultipartFields
-      (Input "type" "photo"
-       : catMaybes
-        [ spoiler <&>
-          \t -> Input "has_spoiler" (bool "false" "true" t)
-        ]) (toMultipart img)
-    InputMediaVideo imgt width height duration streaming spoiler ->
-      addMultipartFields
-      (Input "type" "video"
-      : catMaybes 
-      [ width <&>
-        \t -> Input "width" (TL.toStrict $ encodeToLazyText t)
-      , height <&>
-        \t -> Input "height" (TL.toStrict $ encodeToLazyText t)
-      , duration <&>
-        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
-      , streaming <&>
-        \t -> Input "support_streaming" (bool "false" "true" t)
-      , spoiler <&>
-        \t -> Input "has_spoiler" (bool "false" "true" t)
-      ]) (toMultipart imgt)
-    InputMediaAnimation imgt width height duration spoiler ->
-      addMultipartFields
-      (Input "type" "animation"
-      : catMaybes 
-      [ width <&>
-        \t -> Input "width" (TL.toStrict $ encodeToLazyText t)
-      , height <&>
-        \t -> Input "height" (TL.toStrict $ encodeToLazyText t)
-      , duration <&>
-        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
-      , spoiler <&>
-        \t -> Input "has_spoiler" (bool "false" "true" t)
-      ]) (toMultipart imgt)
-    InputMediaAudio imgt duration performer title ->
-      addMultipartFields
-      (Input "type" "audio"
-      : catMaybes 
-      [ duration <&>
-        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
-      , performer <&>
-        \t -> Input "performer" t
-      , title <&>
-        \t -> Input "title" t
-      ]) (toMultipart imgt)
-    InputMediaDocument imgt dctd ->
-      addMultipartFields
-      (Input "type" "document"
-      : catMaybes 
-      [ dctd <&> 
-         \t -> Input "disable_content_type_detection" (bool "false" "true" t)
-      ]) (toMultipart imgt)
-
--- | Multipart file helper
-makeFile :: Text -> InputFile ->  MultipartData Tmp ->  MultipartData Tmp
-makeFile name (InputFile path ct) (MultipartData fields files) = 
-  MultipartData 
-    (Input name ("attach://" <> name) : fields) 
-    (FileData name (pack $ takeFileName path) ct path : files)
-
-makeFile name file (MultipartData fields files) = 
-  MultipartData 
-    (Input name (TL.toStrict $ encodeToLazyText file) : fields) 
-    files
-
-instance ToJSON MenuButton where
-  toJSON = \case
-    MenuButtonCommands ->
-      object $ addType "commands" []
-    MenuButtonWebApp txt wai ->
-      object $ addType "web_app" ["text" .= txt, "web_app_info" .= wai]
-    MenuButtonDefault ->
-      object $ addType "default" []
-
-instance FromJSON MenuButton where
-  parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Animation.hs
+++ b/src/Telegram/Bot/API/Types/Animation.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Animation where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Animation'
+
+-- | This object represents an animation file (GIF or H.264/MPEG-4 AVC video without sound).
+data Animation = Animation
+  { animationFileId       :: FileId          -- ^ Identifier for this file, which can be used to download or reuse the file.
+  , animationFileUniqueId :: FileId          -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , animationWidth        :: Int           -- ^ Video width as defined by sender.
+  , animationHeight       :: Int           -- ^ Video height as defined by sender.
+  , animationDuration     :: Seconds         -- ^ Duration of the video in seconds as defined by sender.
+  , animationThumb        :: Maybe PhotoSize -- ^ Animation thumbnail as defined by sender.
+  , animationFileName     :: Maybe Text      -- ^ Original animation filename as defined by sender.
+  , animationMimeType     :: Maybe Text      -- ^ MIME type of the file as defined by sender.
+  , animationFileSize     :: Maybe Integer   -- ^ File size in bytes.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Animation

--- a/src/Telegram/Bot/API/Types/Animation.hs
+++ b/src/Telegram/Bot/API/Types/Animation.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Animation where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -25,4 +25,5 @@ data Animation = Animation
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Animation
+instance ToJSON   Animation where toJSON = gtoJSON
+instance FromJSON Animation where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Audio.hs
+++ b/src/Telegram/Bot/API/Types/Audio.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Audio where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -25,4 +25,5 @@ data Audio = Audio
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Audio
+instance ToJSON   Audio where toJSON = gtoJSON
+instance FromJSON Audio where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Audio.hs
+++ b/src/Telegram/Bot/API/Types/Audio.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Audio where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common 
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Audio'
+
+-- | This object represents an audio file to be treated as music by the Telegram clients.
+data Audio = Audio
+  { audioFileId    :: FileId -- ^ Unique identifier for this file.
+  , audioFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , audioDuration  :: Seconds -- ^ Duration of the audio in seconds as defined by sender.
+  , audioPerformer :: Maybe Text -- ^ Performer of the audio as defined by sender or by audio tags.
+  , audioTitle     :: Maybe Text -- ^ Title of the audio as defined by sender or by audio tags.
+  , audioFileName  :: Maybe Text -- ^ Original filename as defined by sender.
+  , audioMimeType  :: Maybe Text -- ^ MIME type of the file as defined by sender.
+  , audioFileSize  :: Maybe Integer -- ^ File size in bytes.
+  , audioThumb     :: Maybe PhotoSize -- ^ Thumbnail of the album cover to which the music file belongs.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Audio

--- a/src/Telegram/Bot/API/Types/BotCommand.hs
+++ b/src/Telegram/Bot/API/Types/BotCommand.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.BotCommand where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'BotCommand'
+
+-- | This object represents a bot command.
+data BotCommand = BotCommand
+  { botCommandCommand :: Text -- ^ Text of the command; 1-32 characters. Can contain only lowercase English letters, digits and underscores.
+  , botCommandDescription :: Text -- ^ Description of the command; 1-256 characters.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''BotCommand

--- a/src/Telegram/Bot/API/Types/BotCommand.hs
+++ b/src/Telegram/Bot/API/Types/BotCommand.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.BotCommand where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -16,4 +16,5 @@ data BotCommand = BotCommand
   }
   deriving (Generic, Show)
 
-deriveJSON' ''BotCommand
+instance ToJSON   BotCommand where toJSON = gtoJSON
+instance FromJSON BotCommand where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/BotCommandScope.hs
+++ b/src/Telegram/Bot/API/Types/BotCommandScope.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Telegram.Bot.API.Types.BotCommandScope where
+
+import Data.Aeson (KeyValue ((.=)), FromJSON (..), ToJSON (..), object, withObject, (.:))
+import Data.Aeson.Types (Parser)
+import Data.Text (Text)
+
+import qualified Data.Text as Text
+
+import Telegram.Bot.API.Types.Common
+
+data BotCommandScope
+  = BotCommandScopeDefault -- ^ Represents the default scope of bot commands. Default commands are used if no commands with a narrower scope are specified for the user.
+  | BotCommandScopeAllPrivateChats -- ^ Represents the scope of bot commands, covering all private chats.
+  | BotCommandScopeAllGroupChats -- ^ Represents the scope of bot commands, covering all group and supergroup chats.
+  | BotCommandScopeAllChatAdministrators -- ^ Represents the scope of bot commands, covering all group and supergroup chat administrators.
+  | BotCommandScopeChat SomeChatId -- ^ Represents the scope of bot commands, covering a specific chat.
+  | BotCommandScopeChatAdministrators SomeChatId -- ^ Represents the scope of bot commands, covering all administrators of a specific group or supergroup chat.
+  | BotCommandScopeChatMember SomeChatId UserId -- ^ Represents the scope of bot commands, covering a specific member of a group or supergroup chat.
+
+instance ToJSON BotCommandScope where
+  toJSON = \case
+    BotCommandScopeDefault ->
+      object $ addType "default" []
+    BotCommandScopeAllPrivateChats ->
+      object $ addType "all_private_chats" []
+    BotCommandScopeAllGroupChats ->
+      object $ addType "all_group_chats" []
+    BotCommandScopeAllChatAdministrators ->
+      object $ addType "all_chat_administrators" []
+    BotCommandScopeChat sci ->
+      object $ addType "chat" ["chat_id" .= sci]
+    BotCommandScopeChatAdministrators sci ->
+      object $ addType "chat_administrators" ["chat_id" .= sci]
+    BotCommandScopeChatMember sci ui ->
+      object $ addType "chat_member" ["chat_id" .= sci, "user_id" .= ui]
+
+instance FromJSON BotCommandScope where
+  parseJSON = withObject "BotCommandScope" \o ->
+    (o .: "type" :: Parser Text) >>= \case
+    "default" ->                pure BotCommandScopeDefault
+    "all_private_chats" ->      pure BotCommandScopeAllPrivateChats
+    "all_group_chats" ->        pure BotCommandScopeAllGroupChats
+    "all_chat_administrators"-> pure BotCommandScopeAllChatAdministrators
+    "chat" ->                        BotCommandScopeChat <$> o .: "chat_id"
+    "chat_administrators"->          BotCommandScopeChatAdministrators <$> o .: "chat_id"
+    "chat_member"->                  BotCommandScopeChatMember <$> o .: "chat_id" <*> o .: "user_id"
+    t -> fail $ Text.unpack ("Unknown type: " <> t)

--- a/src/Telegram/Bot/API/Types/CallbackGame.hs
+++ b/src/Telegram/Bot/API/Types/CallbackGame.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.CallbackGame where
+
+import Data.Aeson (Object)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'CallbackGame'
+
+-- | A placeholder, currently holds no information. Use BotFather to set up your game.
+newtype CallbackGame = CallbackGame Object
+  deriving (Generic, Show)
+
+deriveJSON' ''CallbackGame

--- a/src/Telegram/Bot/API/Types/CallbackGame.hs
+++ b/src/Telegram/Bot/API/Types/CallbackGame.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.CallbackGame where
 
-import Data.Aeson (Object)
+import Data.Aeson (FromJSON (..), ToJSON (..), Object)
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Internal.Utils
@@ -13,4 +12,5 @@ import Telegram.Bot.API.Internal.Utils
 newtype CallbackGame = CallbackGame Object
   deriving (Generic, Show)
 
-deriveJSON' ''CallbackGame
+instance ToJSON   CallbackGame where toJSON = gtoJSON
+instance FromJSON CallbackGame where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/CallbackQuery.hs
+++ b/src/Telegram/Bot/API/Types/CallbackQuery.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.CallbackQuery where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -29,4 +29,5 @@ data CallbackQuery = CallbackQuery
   }
   deriving (Generic, Show)
 
-deriveJSON' ''CallbackQuery
+instance ToJSON   CallbackQuery where toJSON = gtoJSON
+instance FromJSON CallbackQuery where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/CallbackQuery.hs
+++ b/src/Telegram/Bot/API/Types/CallbackQuery.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.CallbackQuery where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.Message
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'CallbackQuery'
+
+-- | This object represents an incoming callback query from a callback button
+-- in an inline keyboard. If the button that originated the query was attached
+-- to a message sent by the bot, the field message will be present.
+-- If the button was attached to a message sent via the bot (in inline mode),
+-- the field @inline_message_id@ will be present.
+-- Exactly one of the fields data or game_short_name will be present.
+data CallbackQuery = CallbackQuery
+  { callbackQueryId              :: CallbackQueryId -- ^ Unique identifier for this query
+  , callbackQueryFrom            :: User -- ^ Sender
+  , callbackQueryMessage         :: Maybe Message -- ^ Message with the callback button that originated the query. Note that message content and message date will not be available if the message is too old
+  , callbackQueryInlineMessageId :: Maybe MessageId -- ^ Identifier of the message sent via the bot in inline mode, that originated the query.
+  , callbackQueryChatInstance    :: Text -- ^ Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent. Useful for high scores in games.
+  , callbackQueryData            :: Maybe Text -- ^ Data associated with the callback button. Be aware that a bad client can send arbitrary data in this field.
+  , callbackQueryGameShortName   :: Maybe Text -- ^ Short name of a Game to be returned, serves as the unique identifier for the game
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''CallbackQuery

--- a/src/Telegram/Bot/API/Types/Chat.hs
+++ b/src/Telegram/Bot/API/Types/Chat.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Chat where
+
+import Data.Aeson (ToJSON(..), FromJSON(..))
+import Data.Time.Clock.POSIX (POSIXTime)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.ChatLocation
+import Telegram.Bot.API.Types.ChatPhoto
+import Telegram.Bot.API.Types.ChatPermissions
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.Message
+import Telegram.Bot.API.Internal.Utils
+
+-- ** Chat
+
+-- | This object represents a chat.
+--
+-- <https://core.telegram.org/bots/api#chat>
+data Chat = Chat
+  { chatId               :: ChatId          -- ^ Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+  , chatType             :: ChatType        -- ^ Type of chat.
+  , chatTitle            :: Maybe Text      -- ^ Title, for supergroups, channels and group chats
+  , chatUsername         :: Maybe Text      -- ^ Username, for private chats, supergroups and channels if available
+  , chatFirstName        :: Maybe Text      -- ^ First name of the other party in a private chat
+  , chatLastName         :: Maybe Text      -- ^ Last name of the other party in a private chat
+  , chatIsForum          :: Maybe Bool      -- ^ 'True', if the supergroup chat is a forum (has topics enabled).
+  , chatPhoto            :: Maybe ChatPhoto -- ^ Chat photo. Returned only in getChat.
+  , chatActiveUsernames  :: Maybe Text      -- ^ If non-empty, the list of all active chat usernames; for private chats, supergroups and channels. Returned only in 'getChat'.
+  , chatEmojiStatusCustomEmojiId :: Maybe Text -- ^ Custom emoji identifier of emoji status of the other party in a private chat. Returned only in 'getChat'.
+  , chatBio              :: Maybe Text      -- ^ Bio of the other party in a private chat. Returned only in `getChat`.
+  , chatHasPrivateForwards :: Maybe Bool    -- ^ 'True', if privacy settings of the other party in the private chat allows to use `tg://user?id=<user_id>` links only in chats with the user. Returned only in getChat.
+  , chatHasRestrictedVoiceAndVideoMessages :: Maybe Bool -- ^ 'True', if the privacy settings of the other party restrict sending voice and video note messages in the private chat. Returned only in 'getChat'.
+  , chatJoinToSendMessages :: Maybe Bool    -- ^ 'True', if users need to join the supergroup before they can send messages. Returned only in 'getChat'.
+  , chatJoinByRequest    :: Maybe Bool      -- ^ 'True', if all users directly joining the supergroup need to be approved by supergroup administrators. Returned only in 'getChat'.
+  , chatDescription      :: Maybe Text      -- ^ Description, for supergroups and channel chats. Returned only in getChat.
+  , chatInviteLink       :: Maybe Text      -- ^ Chat invite link, for supergroups and channel chats. Returned only in getChat.
+  , chatPinnedMessage    :: Maybe Message   -- ^ Pinned message, for supergroups. Returned only in getChat.
+  , chatPermissions      :: Maybe ChatPermissions -- ^ Default chat member permissions, for groups and supergroups.
+  , chatSlowModeDelay    :: Maybe Int       -- ^ For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user; in seconds.
+  , chatMessageAutoDeleteTime :: Maybe POSIXTime -- ^ The time after which all messages sent to the chat will be automatically deleted; in seconds.
+  , chatHasProtectedContent :: Maybe Bool   -- ^ 'True', if messages from the chat can't be forwarded to other chats.
+  , chatStickerSetName   :: Maybe Text      -- ^ For supergroups, name of group sticker set. Returned only in getChat.
+  , chatCanSetStickerSet :: Maybe Bool      -- ^ True, if the bot can change the group sticker set. Returned only in `getChat`.
+  , chatLinkedChatId     :: Maybe ChatId    -- ^ Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. This identifier may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+  , chatLocation         :: Maybe ChatLocation -- ^ For supergroups, the location to which the supergroup is connected. Returned only in getChat.
+  }
+  deriving (Generic, Show)
+
+-- | Type of chat.
+data ChatType
+  = ChatTypePrivate
+  | ChatTypeGroup
+  | ChatTypeSupergroup
+  | ChatTypeChannel
+  deriving (Generic, Show)
+
+instance ToJSON   ChatType where
+  toJSON = gtoJSON
+instance FromJSON ChatType where
+  parseJSON = gparseJSON
+
+deriveJSON' ''Chat

--- a/src/Telegram/Bot/API/Types/Chat.hs
+++ b/src/Telegram/Bot/API/Types/Chat.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Chat where
 
 import Data.Aeson (ToJSON(..), FromJSON(..))
@@ -49,6 +48,9 @@ data Chat = Chat
   }
   deriving (Generic, Show)
 
+instance ToJSON   Chat where toJSON = gtoJSON
+instance FromJSON Chat where parseJSON = gparseJSON
+
 -- | Type of chat.
 data ChatType
   = ChatTypePrivate
@@ -61,5 +63,3 @@ instance ToJSON   ChatType where
   toJSON = gtoJSON
 instance FromJSON ChatType where
   parseJSON = gparseJSON
-
-deriveJSON' ''Chat

--- a/src/Telegram/Bot/API/Types/Chat.hs-boot
+++ b/src/Telegram/Bot/API/Types/Chat.hs-boot
@@ -1,0 +1,11 @@
+module Telegram.Bot.API.Types.Chat where
+
+import Data.Aeson
+
+data Chat
+
+instance Show Chat
+
+instance FromJSON Chat
+
+instance ToJSON Chat

--- a/src/Telegram/Bot/API/Types/ChatAdministratorRights.hs
+++ b/src/Telegram/Bot/API/Types/ChatAdministratorRights.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ChatAdministratorRights where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ChatAdministratorRights'
+
+-- | Represents the rights of an administrator in a chat.
+data ChatAdministratorRights = ChatAdministratorRights
+  { chatAdministratorRightsIsAnonymous         :: Bool -- ^ 'True', if the user's presence in the chat is hidden.
+  , chatAdministratorRightsCanManageChat       :: Bool -- ^ 'True', if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege.
+  , chatAdministratorRightsCanDeleteMessages   :: Bool -- ^ 'True', if the administrator can delete messages of other users.
+  , chatAdministratorRightsCanManageVideoChats :: Bool -- ^ 'True', if the administrator can manage video chats.
+  , chatAdministratorRightsCanRestrictMembers  :: Bool -- ^ 'True', if the administrator can restrict, ban or unban chat members.
+  , chatAdministratorRightsCanPromoteMembers   :: Bool -- ^ 'True', if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user).
+  , chatAdministratorRightsCanChangeInfo       :: Bool -- ^ 'True', if the user is allowed to change the chat title, photo and other settings.
+  , chatAdministratorRightsCanInviteUsers      :: Bool -- ^ 'True', if the user is allowed to invite new users to the chat.
+  , chatAdministratorRightsCanPostMessages     :: Maybe Bool -- ^ 'True', if the administrator can post in the channel; channels only.
+  , chatAdministratorRightsCanEditMessages     :: Maybe Bool -- ^ 'True', if the administrator can edit messages of other users and can pin messages; channels only.
+  , chatAdministratorRightsCanPinMessages      :: Maybe Bool -- ^ 'True', if the user is allowed to pin messages; groups and supergroups only
+  , chatAdministratorRightsCanManageTopics     :: Maybe Bool -- ^ 'True', if the user is allowed to create, rename, close, and reopen forum topics; supergroups only.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ChatAdministratorRights

--- a/src/Telegram/Bot/API/Types/ChatAdministratorRights.hs
+++ b/src/Telegram/Bot/API/Types/ChatAdministratorRights.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ChatAdministratorRights where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Internal.Utils
@@ -25,4 +25,5 @@ data ChatAdministratorRights = ChatAdministratorRights
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ChatAdministratorRights
+instance ToJSON   ChatAdministratorRights where toJSON = gtoJSON
+instance FromJSON ChatAdministratorRights where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ChatInviteLink.hs
+++ b/src/Telegram/Bot/API/Types/ChatInviteLink.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ChatInviteLink where
+
+import Data.Text (Text)
+import Data.Time.Clock.POSIX (POSIXTime)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ChatInviteLink'
+
+-- | Represents an invite link for a chat.
+data ChatInviteLink = ChatInviteLink
+  { chatInviteLinkInviteLink              :: Text            -- ^ The invite link. If the link was created by another chat administrator, then the second part of the link will be replaced with “…”.
+  , chatInviteLinkCreator                 :: User            -- ^ Creator of the link.
+  , chatInviteLinkCreatesJoinRequest      :: Bool            -- ^ 'True', if users joining the chat via the link need to be approved by chat administrators.
+  , chatInviteLinkIsPrimary               :: Bool            -- ^ 'True', if the link is primary.
+  , chatInviteLinkIsRevoked               :: Bool            -- ^ 'True', if the link is revoked.
+  , chatInviteLinkName                    :: Maybe Text      -- ^ Invite link name.
+  , chatInviteLinkExpireDate              :: Maybe POSIXTime -- ^ Point in time (Unix timestamp) when the link will expire or has been expired.
+  , chatInviteLinkMemberLimit             :: Maybe Int     -- ^ Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999.
+  , chatInviteLinkPendingJoinRequestCount :: Maybe Int     -- ^ Number of pending join requests created using this link.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ChatInviteLink

--- a/src/Telegram/Bot/API/Types/ChatInviteLink.hs
+++ b/src/Telegram/Bot/API/Types/ChatInviteLink.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ChatInviteLink where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (POSIXTime)
 import GHC.Generics (Generic)
@@ -25,4 +25,5 @@ data ChatInviteLink = ChatInviteLink
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ChatInviteLink
+instance ToJSON   ChatInviteLink where toJSON = gtoJSON
+instance FromJSON ChatInviteLink where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ChatJoinRequest.hs
+++ b/src/Telegram/Bot/API/Types/ChatJoinRequest.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ChatJoinRequest where
+
+import Data.Text (Text)
+import Data.Time.Clock.POSIX (POSIXTime)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.Chat
+import Telegram.Bot.API.Types.ChatInviteLink
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ChatJoinRequest'
+
+-- | Represents a join request sent to a chat.
+data ChatJoinRequest = ChatJoinRequest
+  { chatJoinRequestChat       :: Chat                 -- ^ Chat to which the request was sent.
+  , chatJoinRequestFrom       :: User                 -- ^ User that sent the join request.
+  , chatJoinRequestUserChatId :: ChatId               -- ^ Identifier of a private chat with the user who sent the join request. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot can use this identifier for 24 hours to send messages until the join request is processed, assuming no other administrator contacted the user.
+  , chatJoinRequestDate       :: POSIXTime            -- ^ Date the request was sent in Unix time.
+  , chatJoinRequestBio        :: Maybe Text           -- ^ Bio of the user.
+  , chatJoinRequestInviteLink :: Maybe ChatInviteLink -- ^ Chat invite link that was used by the user to send the join request.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ChatJoinRequest

--- a/src/Telegram/Bot/API/Types/ChatJoinRequest.hs
+++ b/src/Telegram/Bot/API/Types/ChatJoinRequest.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ChatJoinRequest where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (POSIXTime)
 import GHC.Generics (Generic)
@@ -25,4 +25,6 @@ data ChatJoinRequest = ChatJoinRequest
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ChatJoinRequest
+instance ToJSON   ChatJoinRequest where toJSON = gtoJSON
+instance FromJSON ChatJoinRequest where parseJSON = gparseJSON
+

--- a/src/Telegram/Bot/API/Types/ChatLocation.hs
+++ b/src/Telegram/Bot/API/Types/ChatLocation.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ChatLocation where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -17,4 +17,5 @@ data ChatLocation = ChatLocation
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ChatLocation
+instance ToJSON   ChatLocation where toJSON = gtoJSON
+instance FromJSON ChatLocation where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ChatLocation.hs
+++ b/src/Telegram/Bot/API/Types/ChatLocation.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ChatLocation where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Location
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ChatLocation'
+
+-- | Represents a location to which a chat is connected.
+data ChatLocation = ChatLocation
+  { chatLocationLocation :: Location -- ^ The location to which the supergroup is connected. Can't be a live location..
+  , chatLocationAddress :: Text      -- ^ Location address; 1-64 characters, as defined by the chat owner.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ChatLocation

--- a/src/Telegram/Bot/API/Types/ChatMember.hs
+++ b/src/Telegram/Bot/API/Types/ChatMember.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ChatMember where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (POSIXTime)
 import GHC.Generics (Generic)
@@ -54,4 +54,5 @@ data ChatMember = ChatMember
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ChatMember
+instance ToJSON   ChatMember where toJSON = gtoJSON
+instance FromJSON ChatMember where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ChatMember.hs
+++ b/src/Telegram/Bot/API/Types/ChatMember.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ChatMember where
+
+import Data.Text (Text)
+import Data.Time.Clock.POSIX (POSIXTime)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ChatMember'
+
+-- | This object contains information about one member of a chat.
+data ChatMember = ChatMember
+  { chatMemberUser                  :: User -- ^ Information about the user
+  , chatMemberStatus                :: Text -- ^ The member's status in the chat. Can be “owner”, “administrator”, “member”, “restricted”, “left” or “banned”.
+
+  -- banned, restricted
+  , chatMemberUntilDate             :: Maybe POSIXTime -- ^ Restictred and banned only. Date when restrictions will be lifted for this user, unix time.
+
+  -- owner, administrator
+  , chatMemberIsAnonymous           :: Maybe Bool -- ^ Owners and administrators only. 'True', if the user's presence in the chat is hidden.
+  , chatMemberCustomTitle           :: Maybe Text -- ^ Owners and administrators only. Custom title for this user.
+
+  -- administrator
+  , chatMemberCanBeEdited           :: Maybe Bool -- ^ Administrators only. 'True', if the bot is allowed to edit administrator privileges of that user
+  , chatMemberCanManageChat         :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege.
+  , chatMemberCanDeleteMessages     :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can delete messages of other users.
+  , chatMemberCanManageVideoChats   :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can manage video (previously, voice) chats.
+  , chatMemberCanRestrictMembers    :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can restrict, ban or unban chat members.
+  , chatMemberCanPromoteMembers     :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user).
+  , chatMemberCanChangeInfo         :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can change the chat title, photo and other settings.
+  , chatMemberCanPostMessages       :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can post in the channel, channels only.
+  , chatMemberCanEditMessages       :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can edit messages of other users and can pin messages, channels only.
+
+  -- administrator, restricted
+  , chatMemberCanInviteUsers        :: Maybe Bool -- ^ Administrators and restricted only. 'True', if the administrator can invite new users to the chat.
+  , chatMemberCanPinMessages        :: Maybe Bool -- ^ Administrators and restricted only. 'True', if the administrator can pin messages, supergroups only.
+  , chatMemberCanManageTopics       :: Maybe Bool -- ^ Administrators and restricted only. 'True', if the user is allowed to create, rename, close, and reopen forum topics; supergroups only.
+
+  -- restricted
+  , chatMemberIsMember              :: Maybe Bool -- ^ Restricted only. 'True', if the user is a member of the chat at the moment of the request.
+  , chatMemberCanSendMessages       :: Maybe Bool -- ^ Restricted only. 'True', if the user can send text messages, contacts, locations and venues.
+  , chatMemberCanSendAudios         :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send audios.
+  , chatMemberCanSendDocuments      :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send documents.
+  , chatMemberCanSendPhotos         :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send photos.
+  , chatMemberCanSendVideos         :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send videos.
+  , chatMemberCanSendVideoNotes     :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send video notes.
+  , chatMemberCanSendVoiceNotes     :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send voice notes.
+  , chatMemberCanSendPolls          :: Maybe Bool -- ^ Restricted only. 'True', if the user is allowed to send polls.
+  , chatMemberCanSendOtherMessages  :: Maybe Bool -- ^ Restricted only. 'True', if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages.
+  , chatMemberCanAddWebPagePreviews :: Maybe Bool -- ^ Restricted only. 'True', if user may add web page previews to his messages, implies can_send_media_messages.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ChatMember

--- a/src/Telegram/Bot/API/Types/ChatMemberUpdated.hs
+++ b/src/Telegram/Bot/API/Types/ChatMemberUpdated.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ChatMemberUpdated where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Time.Clock.POSIX (POSIXTime)
 import GHC.Generics (Generic)
 
@@ -24,4 +24,7 @@ data ChatMemberUpdated = ChatMemberUpdated
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ChatMemberUpdated
+instance ToJSON   ChatMemberUpdated where toJSON = gtoJSON
+instance FromJSON ChatMemberUpdated where parseJSON = gparseJSON
+
+

--- a/src/Telegram/Bot/API/Types/ChatMemberUpdated.hs
+++ b/src/Telegram/Bot/API/Types/ChatMemberUpdated.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ChatMemberUpdated where
+
+import Data.Time.Clock.POSIX (POSIXTime)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Chat
+import Telegram.Bot.API.Types.ChatInviteLink
+import Telegram.Bot.API.Types.ChatMember
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ChatMemberUpdated'
+
+-- | This object represents changes in the status of a chat member.
+data ChatMemberUpdated = ChatMemberUpdated
+  { chatMemberUpdatedChat          :: Chat                 -- ^ Chat the user belongs to.
+  , chatMemberUpdatedFrom          :: User                 -- ^ Performer of the action, which resulted in the change.
+  , chatMemberUpdatedDate          :: POSIXTime            -- ^ Date the change was done in Unix time.
+  , chatMemberUpdatedOldChatMember :: ChatMember           -- ^ Previous information about the chat member.
+  , chatMemberUpdatedNewChatMember :: ChatMember           -- ^ New information about the chat member.
+  , chatMemberUpdatedInviteLink    :: Maybe ChatInviteLink -- ^ Chat invite link, which was used by the user to join the chat; for joining by invite link events only.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ChatMemberUpdated

--- a/src/Telegram/Bot/API/Types/ChatPermissions.hs
+++ b/src/Telegram/Bot/API/Types/ChatPermissions.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ChatPermissions where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ChatPermissions'
+
+-- | Describes actions that a non-administrator user is allowed to take in a chat.
+data ChatPermissions = ChatPermissions
+  { chatPermissionsCanSendMessages :: Maybe Bool       -- ^ 'True', if the user is allowed to send text messages, contacts, locations and venues.
+  , chatPermissionsCanSendAudios     :: Maybe Bool     -- ^ 'True', if the user is allowed to send audios.
+  , chatPermissionsCanSendDocuments  :: Maybe Bool     -- ^ 'True', if the user is allowed to send documents.
+  , chatPermissionsCanSendPhotos     :: Maybe Bool     -- ^ 'True', if the user is allowed to send photos.
+  , chatPermissionsCanSendVideos     :: Maybe Bool     -- ^ 'True', if the user is allowed to send videos.
+  , chatPermissionsCanSendVideoNotes :: Maybe Bool     -- ^ 'True', if the user is allowed to send video notes.
+  , chatPermissionsCanSendVoiceNotes :: Maybe Bool     -- ^ 'True', if the user is allowed to send voice notes.
+  , chatPermissionsCanSendPolls :: Maybe Bool          -- ^ 'True', if the user is allowed to send polls, implies can_send_messages.
+  , chatPermissionsCanSendOtherMessages :: Maybe Bool  -- ^ 'True', if the user is allowed to send animations, games, stickers and use inline bots, implies can_send_media_messages.
+  , chatPermissionsCanAddWebPagePreviews :: Maybe Bool -- ^ 'True', if the user is allowed to add web page previews to their messages, implies can_send_media_messages.
+  , chatPermissionsCanChangeInfo :: Maybe Bool         -- ^ 'True', if the user is allowed to change the chat title, photo and other settings. Ignored in public supergroups
+  , chatPermissionsCanInviteUsers :: Maybe Bool        -- ^ 'True', if the user is allowed to invite new users to the chat.
+  , chatPermissionsCanPinMessages :: Maybe Bool        -- ^ 'True', if the user is allowed to pin messages. Ignored in public supergroups.
+  , chatPermissionsCanManageTopics :: Maybe Bool       -- ^ 'True', if the user is allowed to create forum topics. If omitted defaults to the value of can_pin_messages.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ChatPermissions

--- a/src/Telegram/Bot/API/Types/ChatPermissions.hs
+++ b/src/Telegram/Bot/API/Types/ChatPermissions.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ChatPermissions where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Internal.Utils
@@ -27,4 +27,5 @@ data ChatPermissions = ChatPermissions
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ChatPermissions
+instance ToJSON   ChatPermissions where toJSON = gtoJSON
+instance FromJSON ChatPermissions where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ChatPhoto.hs
+++ b/src/Telegram/Bot/API/Types/ChatPhoto.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ChatPhoto where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common 
@@ -18,4 +18,5 @@ data ChatPhoto = ChatPhoto
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ChatPhoto
+instance ToJSON   ChatPhoto where toJSON = gtoJSON
+instance FromJSON ChatPhoto where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ChatPhoto.hs
+++ b/src/Telegram/Bot/API/Types/ChatPhoto.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ChatPhoto where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common 
+import Telegram.Bot.API.Internal.Utils
+
+-- ** Chat photo
+
+-- | Chat photo. Returned only in getChat.
+data ChatPhoto = ChatPhoto
+  { chatPhotoSmallFileId       :: FileId -- ^ Unique file identifier of small (160x160) chat photo. This file_id can be used only for photo download.
+  , chatPhotoSmallFileUniqueId :: FileId -- ^ Unique file identifier of small (160x160) chat photo, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , chatPhotoBigFileId         :: FileId -- ^ Unique file identifier of big (640x640) chat photo. This file_id can be used only for photo download.
+  , chatPhotoBigFileUniqueId   :: FileId -- ^ Unique file identifier of big (640x640) chat photo, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ChatPhoto

--- a/src/Telegram/Bot/API/Types/ChatShared.hs
+++ b/src/Telegram/Bot/API/Types/ChatShared.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ChatShared where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -16,4 +16,5 @@ data ChatShared = ChatShared
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ChatShared
+instance ToJSON   ChatShared where toJSON = gtoJSON
+instance FromJSON ChatShared where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ChatShared.hs
+++ b/src/Telegram/Bot/API/Types/ChatShared.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ChatShared where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ChatShared'
+
+-- | This object contains information about the chat whose identifier was shared with the bot using a 'KeyboardButtonRequestChat' button.
+data ChatShared = ChatShared
+  { chatSharedRequestId :: RequestId -- ^ Identifier of the request.
+  , chatSharedChatId :: ChatId -- ^ Identifier of the shared chat. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the chat and could be unable to use this identifier, unless the chat is already known to the bot by some other means.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ChatShared

--- a/src/Telegram/Bot/API/Types/Common.hs
+++ b/src/Telegram/Bot/API/Types/Common.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+module Telegram.Bot.API.Types.Common where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), KeyValue ((.=)))
+import Data.Aeson.Types (Pair)
+import Data.Coerce (coerce)
+import Data.Hashable (Hashable)
+import Data.Text (Text, pack)
+import GHC.Generics (Generic)
+import Servant.API (ToHttpApiData (..))
+
+import Telegram.Bot.API.Internal.Utils
+
+-- | Unique identifier for this file.
+newtype FileId = FileId Text
+  deriving (Eq, Show, ToJSON, FromJSON)
+
+instance ToHttpApiData FileId where
+  toUrlPiece = coerce
+
+newtype Seconds = Seconds Int
+  deriving (Eq, Show, Num, ToJSON, FromJSON)
+
+-- | Unique identifier for this user or bot.
+newtype UserId = UserId Integer
+  deriving (Eq, Show, ToJSON, FromJSON)
+
+instance ToHttpApiData UserId where
+  toUrlPiece = pack . show @Integer . coerce
+
+-- | Unique identifier for this chat.
+newtype ChatId = ChatId Integer
+  deriving (Eq, Show, ToJSON, FromJSON, Hashable)
+
+instance ToHttpApiData ChatId where
+  toUrlPiece a = pack . show @Integer $ coerce a
+
+-- | Unique message identifier inside this chat.
+newtype MessageId = MessageId Integer
+  deriving (Eq, Show, ToJSON, FromJSON, Hashable)
+
+instance ToHttpApiData MessageId where
+  toUrlPiece a = pack . show @Integer $ coerce a
+
+-- | Unique identifier of a message thread to which the message belongs; for supergroups only.
+newtype MessageThreadId = MessageThreadId Integer
+  deriving (Eq, Show, ToJSON, FromJSON, Hashable)
+
+instance ToHttpApiData MessageThreadId where
+  toUrlPiece a = pack . show @Integer $ coerce a
+
+-- | The unique identifier of a media message group a message belongs to.
+newtype MediaGroupId = MediaGroupId Text
+  deriving (Eq, Show, ToJSON, FromJSON)
+
+-- | Signed 32-bit identifier of the request, which will be received back in the 'UserShared' or 'ChatShared' object. Must be unique within the message.
+newtype RequestId = RequestId Integer
+  deriving (Eq, Show, ToJSON, FromJSON)
+
+-- | Unique poll identifier.
+newtype PollId = PollId Text
+  deriving (Eq, Show, ToJSON, FromJSON)
+
+newtype ShippingOptionId = ShippingOptionId Text
+  deriving (Eq, Show, Generic, ToJSON, FromJSON)
+
+newtype WebAppInfo = WebAppInfo { webAppInfoUrl :: Text }
+  deriving (Generic, Show, ToJSON, FromJSON)
+
+newtype CallbackQueryId = CallbackQueryId Text
+  deriving (Eq, Show, Generic, ToJSON, FromJSON)
+
+-- | Unique identifier for the target chat
+-- or username of the target channel (in the format @\@channelusername@).
+data SomeChatId
+  = SomeChatId ChatId       -- ^ Unique chat ID.
+  | SomeChatUsername Text   -- ^ Username of the target channel.
+  deriving (Generic)
+
+instance ToJSON   SomeChatId where toJSON = genericSomeToJSON
+instance FromJSON SomeChatId where parseJSON = genericSomeParseJSON
+
+instance ToHttpApiData SomeChatId where
+  toUrlPiece (SomeChatId chatid) = toUrlPiece chatid
+  toUrlPiece (SomeChatUsername name) = name
+
+addType :: Text -> [Pair] -> [Pair]
+addType name xs = ("type" .= name) : xs
+

--- a/src/Telegram/Bot/API/Types/Contact.hs
+++ b/src/Telegram/Bot/API/Types/Contact.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Contact where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common 
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Contact'
+
+-- | This object represents a phone contact.
+data Contact = Contact
+  { contactPhoneNumber :: Text -- ^ Contact's phone number.
+  , contactFirstName   :: Text -- ^ Contact's first name.
+  , contactLastName    :: Maybe Text -- ^ Contact's last name.
+  , contactUserId      :: Maybe UserId -- ^ Contact's user identifier in Telegram.
+  , contactVcard       :: Maybe Text -- ^ Additional data about the contact in the form of a vCard.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Contact

--- a/src/Telegram/Bot/API/Types/Contact.hs
+++ b/src/Telegram/Bot/API/Types/Contact.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Contact where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -20,4 +20,5 @@ data Contact = Contact
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Contact
+instance ToJSON   Contact where toJSON = gtoJSON
+instance FromJSON Contact where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/CopyMessageId.hs
+++ b/src/Telegram/Bot/API/Types/CopyMessageId.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.CopyMessageId where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'CopyMessageId'
+
+-- | This object represents result of copyMessage request.
+data CopyMessageId = CopyMessageId
+  { copyMessageIdMessageId :: MessageId -- ^ the MessageId of the sent message.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''CopyMessageId

--- a/src/Telegram/Bot/API/Types/CopyMessageId.hs
+++ b/src/Telegram/Bot/API/Types/CopyMessageId.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.CopyMessageId where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -15,4 +15,5 @@ data CopyMessageId = CopyMessageId
   }
   deriving (Generic, Show)
 
-deriveJSON' ''CopyMessageId
+instance ToJSON   CopyMessageId where toJSON = gtoJSON
+instance FromJSON CopyMessageId where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Dice.hs
+++ b/src/Telegram/Bot/API/Types/Dice.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Dice where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -16,4 +16,5 @@ data Dice = Dice
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Dice
+instance ToJSON   Dice where toJSON = gtoJSON
+instance FromJSON Dice where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Dice.hs
+++ b/src/Telegram/Bot/API/Types/Dice.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Dice where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Dice'
+
+-- | This object represents an animated emoji that displays a random value.
+data Dice = Dice
+  { diceEmoji :: Text -- ^ Emoji on which the dice throw animation is based.
+  , diceValue :: Int  -- ^ Value of the dice, 1-6 for “🎲”, “🎯” and “🎳” base emoji, 1-5 for “🏀” and “⚽” base emoji, 1-64 for “🎰” base emoji
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Dice

--- a/src/Telegram/Bot/API/Types/Document.hs
+++ b/src/Telegram/Bot/API/Types/Document.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Document where 
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -22,4 +22,5 @@ data Document = Document
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Document
+instance ToJSON   Document where toJSON = gtoJSON
+instance FromJSON Document where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Document.hs
+++ b/src/Telegram/Bot/API/Types/Document.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Document where 
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common 
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Document'
+
+-- | This object represents a general file (as opposed to photos, voice messages and audio files).
+data Document = Document
+  { documentFileId   :: FileId -- ^ Unique file identifier.
+  , documentFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , documentThumb    :: Maybe PhotoSize -- ^ Document thumbnail as defined by sender.
+  , documentFileName :: Maybe Text -- ^ Original filename as defined by sender.
+  , documentMimeType :: Maybe Text -- ^ MIME type of the file as defined by sender.
+  , documentFileSize :: Maybe Integer -- ^ File size in bytes. 
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Document

--- a/src/Telegram/Bot/API/Types/EncryptedCredentials.hs
+++ b/src/Telegram/Bot/API/Types/EncryptedCredentials.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.EncryptedCredentials where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -17,4 +17,5 @@ data EncryptedCredentials = EncryptedCredentials
   }
   deriving (Generic, Show)
 
-deriveJSON' ''EncryptedCredentials
+instance ToJSON   EncryptedCredentials where toJSON = gtoJSON
+instance FromJSON EncryptedCredentials where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/EncryptedCredentials.hs
+++ b/src/Telegram/Bot/API/Types/EncryptedCredentials.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.EncryptedCredentials where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'EncryptedCredentials'
+
+-- | Contains data required for decrypting and authenticating EncryptedPassportElement. See the Telegram Passport Documentation for a complete description of the data decryption and authentication processes.
+data EncryptedCredentials = EncryptedCredentials
+  { encryptedCredentialsData   :: Text -- ^ Base64-encoded encrypted JSON-serialized data with unique user's payload, data hashes and secrets required for EncryptedPassportElement decryption and authentication.
+  , encryptedCredentialsHash   :: Text -- ^ Base64-encoded data hash for data authentication.
+  , encryptedCredentialsSecret :: Text -- ^ Base64-encoded secret, encrypted with the bot's public RSA key, required for data decryption
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''EncryptedCredentials

--- a/src/Telegram/Bot/API/Types/EncryptedPassportElement.hs
+++ b/src/Telegram/Bot/API/Types/EncryptedPassportElement.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.EncryptedPassportElement where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -24,6 +24,8 @@ data EncryptedPassportElement = EncryptedPassportElement
   , encryptedPassportElementHash        :: Text                 -- ^ Base64-encoded element hash for using in 'PassportElementErrorUnspecified'.
   } deriving (Generic, Show)
 
+instance ToJSON   EncryptedPassportElement where toJSON = gtoJSON
+instance FromJSON EncryptedPassportElement where parseJSON = gparseJSON
 
 -- | One of “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport”, “address”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration”, “temporary_registration”, “phone_number”, “email”.
 data PassportElementType
@@ -42,7 +44,5 @@ data PassportElementType
   | PassportElementTypeEmail
   deriving (Generic, Show)
 
-foldMap deriveJSON'
-  [ ''EncryptedPassportElement
-  , ''PassportElementType
-  ]
+instance ToJSON   PassportElementType where toJSON = gtoJSON
+instance FromJSON PassportElementType where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/EncryptedPassportElement.hs
+++ b/src/Telegram/Bot/API/Types/EncryptedPassportElement.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.EncryptedPassportElement where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.PassportFile
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'EncryptedPassportElement'
+
+-- | Contains information about documents or other Telegram Passport elements shared with the bot by the user.
+data EncryptedPassportElement = EncryptedPassportElement
+  { encryptedPassportElementType        :: PassportElementType  -- ^ One of “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport”, “address”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration”, “temporary_registration”, “phone_number”, “email”.
+  , encryptedPassportElementData        :: Maybe Text           -- ^ Base64-encoded encrypted Telegram Passport element data provided by the user, available for “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport” and “address” types. Can be decrypted and verified using the accompanying 'EncryptedCredentials'.
+  , encryptedPassportElementPhoneNumber :: Maybe Text           -- ^ User's verified phone number, available only for “phone_number” type.
+  , encryptedPassportElementEmail       :: Maybe Text           -- ^ User's verified email address, available only for “email” type.
+  , encryptedPassportElementFiles       :: Maybe [PassportFile] -- ^ Array of encrypted files with documents provided by the user, available for “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration” and “temporary_registration” types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
+  , encryptedPassportElementFrontSide   :: Maybe PassportFile   -- ^ Encrypted file with the front side of the document, provided by the user. Available for “passport”, “driver_license”, “identity_card” and “internal_passport”. The file can be decrypted and verified using the accompanying EncryptedCredentials.
+  , encryptedPassportElementReverseSide :: Maybe PassportFile   -- ^ Encrypted file with the reverse side of the document, provided by the user. Available for “driver_license” and “identity_card”. The file can be decrypted and verified using the accompanying EncryptedCredentials.
+  , encryptedPassportElementSelfie      :: Maybe PassportFile   -- ^ Encrypted file with the selfie of the user holding a document, provided by the user; available for “passport”, “driver_license”, “identity_card” and “internal_passport”. The file can be decrypted and verified using the accompanying EncryptedCredentials.
+  , encryptedPassportElementTranslation :: Maybe [PassportFile] -- ^ Array of encrypted files with translated versions of documents provided by the user. Available if requested for “passport”, “driver_license”, “identity_card”, “internal_passport”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration” and “temporary_registration” types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
+  , encryptedPassportElementHash        :: Text                 -- ^ Base64-encoded element hash for using in 'PassportElementErrorUnspecified'.
+  } deriving (Generic, Show)
+
+
+-- | One of “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport”, “address”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration”, “temporary_registration”, “phone_number”, “email”.
+data PassportElementType
+  = PassportElementTypePersonalDetails
+  | PassportElementTypePassport
+  | PassportElementTypeDriverLicense
+  | PassportElementTypeIdentityCard
+  | PassportElementTypeInternalPassport
+  | PassportElementTypeAddress
+  | PassportElementTypeUtilityBill
+  | PassportElementTypeBankStatement
+  | PassportElementTypeRentalAgreement
+  | PassportElementTypePassportRegistration
+  | PassportElementTypeTemporaryRegistration
+  | PassportElementTypePhoneNumber
+  | PassportElementTypeEmail
+  deriving (Generic, Show)
+
+foldMap deriveJSON'
+  [ ''EncryptedPassportElement
+  , ''PassportElementType
+  ]

--- a/src/Telegram/Bot/API/Types/File.hs
+++ b/src/Telegram/Bot/API/Types/File.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.File where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common 
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'File'
+
+-- | This object represents a file ready to be downloaded.
+-- The file can be downloaded via the link @https://api.telegram.org/file/bot<token>/<file_path>@.
+-- It is guaranteed that the link will be valid for at least 1 hour.
+-- When the link expires, a new one can be requested by calling getFile.
+data File = File
+  { fileFileId       :: FileId      -- ^ Unique identifier for this file.
+  , fileFileUniqueId :: FileId      -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , fileFileSize     :: Maybe Integer -- ^ File size in bytes, if known.
+  , fileFilePath     :: Maybe Text  -- ^ File path. Use https://api.telegram.org/file/bot<token>/<file_path> to get the file.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''File

--- a/src/Telegram/Bot/API/Types/File.hs
+++ b/src/Telegram/Bot/API/Types/File.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.File where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -22,4 +22,5 @@ data File = File
   }
   deriving (Generic, Show)
 
-deriveJSON' ''File
+instance ToJSON   File where toJSON = gtoJSON
+instance FromJSON File where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ForceReply.hs
+++ b/src/Telegram/Bot/API/Types/ForceReply.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ForceReply where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ForceReply'
+
+-- | Upon receiving a message with this object,
+-- Telegram clients will display a reply interface to the user
+-- (act as if the user has selected the bot‘s message and tapped ’Reply').
+-- This can be extremely useful if you want to create user-friendly
+-- step-by-step interfaces without having to sacrifice privacy mode.
+data ForceReply = ForceReply
+  { forceReplyForceReply            :: Bool       -- ^ Shows reply interface to the user, as if they manually selected the bot‘s message and tapped ’Reply'
+  , forceReplyInputFieldPlaceholder :: Maybe Text -- ^ The placeholder to be shown in the input field when the reply is active; 1-64 characters.
+  , forceReplySelective             :: Maybe Bool -- ^ Use this parameter if you want to force reply from specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ForceReply

--- a/src/Telegram/Bot/API/Types/ForceReply.hs
+++ b/src/Telegram/Bot/API/Types/ForceReply.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ForceReply where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -21,4 +21,5 @@ data ForceReply = ForceReply
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ForceReply
+instance ToJSON   ForceReply where toJSON = gtoJSON
+instance FromJSON ForceReply where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ForumTopic.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopic.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ForumTopic where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -19,4 +19,5 @@ data ForumTopic = ForumTopic
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ForumTopic
+instance ToJSON   ForumTopic where toJSON = gtoJSON
+instance FromJSON ForumTopic where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ForumTopic.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopic.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ForumTopic where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ForumTopic'
+
+-- | This object represents a forum topic.
+data ForumTopic = ForumTopic
+  { forumTopicMessageThreadId   :: MessageThreadId -- ^ Unique identifier of the forum topic
+  , forumTopicName              :: Text            -- ^ Name of the topic
+  , forumTopicIconColor         :: Integer         -- ^ Color of the topic icon in RGB format.
+  , forumTopicIconCustomEmojiId :: Maybe Text      -- ^ Unique identifier of the custom emoji shown as the topic icon.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ForumTopic

--- a/src/Telegram/Bot/API/Types/ForumTopicClosed.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopicClosed.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ForumTopicClosed where
 
-import Data.Aeson (Object)
+import Data.Aeson (FromJSON (..), ToJSON (..), Object)
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Internal.Utils
@@ -13,4 +12,5 @@ import Telegram.Bot.API.Internal.Utils
 newtype ForumTopicClosed = ForumTopicClosed Object
   deriving (Generic, Show)
 
-deriveJSON' ''ForumTopicClosed
+instance ToJSON   ForumTopicClosed where toJSON = gtoJSON
+instance FromJSON ForumTopicClosed where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ForumTopicClosed.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopicClosed.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ForumTopicClosed where
+
+import Data.Aeson (Object)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ForumTopicClosed'
+
+-- | This object represents a service message about a forum topic closed in the chat. Currently holds no information.
+newtype ForumTopicClosed = ForumTopicClosed Object
+  deriving (Generic, Show)
+
+deriveJSON' ''ForumTopicClosed

--- a/src/Telegram/Bot/API/Types/ForumTopicCreated.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopicCreated.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ForumTopicCreated where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ForumTopicCreated'
+
+-- | This object represents a service message about a new forum topic created in the chat.
+data ForumTopicCreated = ForumTopicCreated
+  { forumTopicCreatedName              :: Text       -- ^ Name of the topic.
+  , forumTopicCreatedIconColor         :: Integer    -- ^ Color of the topic icon in RGB format.
+  , forumTopicCreatedIconCustomEmojiId :: Maybe Text -- ^ Unique identifier of the custom emoji shown as the topic icon.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ForumTopicCreated

--- a/src/Telegram/Bot/API/Types/ForumTopicCreated.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopicCreated.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ForumTopicCreated where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -17,4 +17,5 @@ data ForumTopicCreated = ForumTopicCreated
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ForumTopicCreated
+instance ToJSON   ForumTopicCreated where toJSON = gtoJSON
+instance FromJSON ForumTopicCreated where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ForumTopicEdited.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopicEdited.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ForumTopicEdited where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -16,4 +16,5 @@ data ForumTopicEdited = ForumTopicEdited
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ForumTopicEdited
+instance ToJSON   ForumTopicEdited where toJSON = gtoJSON
+instance FromJSON ForumTopicEdited where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ForumTopicEdited.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopicEdited.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ForumTopicEdited where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ForumTopicEdited'
+
+-- | This object represents a service message about an edited forum topic.
+data ForumTopicEdited = ForumTopicEdited
+  { forumTopicEditedName              :: Maybe Text -- ^ New name of the topic, if it was edited.
+  , forumTopicEditedIconCustomEmojiId :: Maybe Text -- ^ New identifier of the custom emoji shown as the topic icon, if it was edited; an empty string if the icon was removed.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ForumTopicEdited

--- a/src/Telegram/Bot/API/Types/ForumTopicReopened.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopicReopened.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ForumTopicReopened where
 
-import Data.Aeson (Object)
+import Data.Aeson (FromJSON (..), ToJSON (..), Object)
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Internal.Utils
@@ -13,4 +12,5 @@ import Telegram.Bot.API.Internal.Utils
 newtype ForumTopicReopened = ForumTopicReopened Object
   deriving (Generic, Show)
 
-deriveJSON' ''ForumTopicReopened
+instance ToJSON   ForumTopicReopened where toJSON = gtoJSON
+instance FromJSON ForumTopicReopened where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ForumTopicReopened.hs
+++ b/src/Telegram/Bot/API/Types/ForumTopicReopened.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ForumTopicReopened where
+
+import Data.Aeson (Object)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ForumTopicReopened'
+
+-- | This object represents a service message about a forum topic reopened in the chat. Currently holds no information.
+newtype ForumTopicReopened = ForumTopicReopened Object
+  deriving (Generic, Show)
+
+deriveJSON' ''ForumTopicReopened

--- a/src/Telegram/Bot/API/Types/Game.hs
+++ b/src/Telegram/Bot/API/Types/Game.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Game where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Animation
+import Telegram.Bot.API.Types.MessageEntity
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Game'
+
+-- | This object represents a game. Use BotFather to create and edit games, their short names will act as unique identifiers.
+data Game = Game
+  { gameTitle        :: Text                  -- ^ Title of the game.
+  , gameDescription  :: Text                  -- ^ Description of the game.
+  , gamePhoto        :: [PhotoSize]           -- ^ Photo that will be displayed in the game message in chats.
+  , gameText         :: Maybe Text            -- ^ Brief description of the game or high scores included in the game message. Can be automatically edited to include current high scores for the game when the bot calls setGameScore, or manually edited using editMessageText. 0-4096 characters.
+  , gameTextEntities :: Maybe [MessageEntity] -- ^ Special entities that appear in text, such as usernames, URLs, bot commands, etc.
+  , gameAnimation    :: Maybe Animation       -- ^ Animation that will be displayed in the game message in chats. Upload via @BotFather@.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Game

--- a/src/Telegram/Bot/API/Types/Game.hs
+++ b/src/Telegram/Bot/API/Types/Game.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Game where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -23,4 +23,5 @@ data Game = Game
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Game
+instance ToJSON   Game where toJSON = gtoJSON
+instance FromJSON Game where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/GameHighScore.hs
+++ b/src/Telegram/Bot/API/Types/GameHighScore.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.GameHighScore where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'GameHighScore'
+
+-- | This object represents one row of the high scores table for a game.
+data GameHighScore = GameHighScore
+  { gameHighScorePosition :: Int -- ^ Position in high score table for the game.
+  , gameHighScoreUser     :: User  -- ^ User.
+  , gameHighScoreScore    :: Int -- ^ Score.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''GameHighScore

--- a/src/Telegram/Bot/API/Types/GameHighScore.hs
+++ b/src/Telegram/Bot/API/Types/GameHighScore.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.GameHighScore where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.User
@@ -17,4 +17,5 @@ data GameHighScore = GameHighScore
   }
   deriving (Generic, Show)
 
-deriveJSON' ''GameHighScore
+instance ToJSON   GameHighScore where toJSON = gtoJSON
+instance FromJSON GameHighScore where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/GeneralForumTopicHidden.hs
+++ b/src/Telegram/Bot/API/Types/GeneralForumTopicHidden.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.GeneralForumTopicHidden where
+
+import Data.Aeson (Object)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'GeneralForumTopicHidden'
+
+-- | This object represents a service message about General forum topic hidden in the chat. Currently holds no information.
+newtype GeneralForumTopicHidden = GeneralForumTopicHidden Object
+  deriving (Generic, Show)
+
+deriveJSON' ''GeneralForumTopicHidden

--- a/src/Telegram/Bot/API/Types/GeneralForumTopicHidden.hs
+++ b/src/Telegram/Bot/API/Types/GeneralForumTopicHidden.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.GeneralForumTopicHidden where
 
-import Data.Aeson (Object)
+import Data.Aeson (FromJSON (..), ToJSON (..), Object)
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Internal.Utils
@@ -13,4 +12,5 @@ import Telegram.Bot.API.Internal.Utils
 newtype GeneralForumTopicHidden = GeneralForumTopicHidden Object
   deriving (Generic, Show)
 
-deriveJSON' ''GeneralForumTopicHidden
+instance ToJSON   GeneralForumTopicHidden where toJSON = gtoJSON
+instance FromJSON GeneralForumTopicHidden where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/GeneralForumTopicUnhidden.hs
+++ b/src/Telegram/Bot/API/Types/GeneralForumTopicUnhidden.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.GeneralForumTopicUnhidden where
+
+import Data.Aeson (Object)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'GeneralForumTopicUnhidden'
+
+-- | This object represents a service message about General forum topic unhidden in the chat. Currently holds no information.
+newtype GeneralForumTopicUnhidden = GeneralForumTopicUnhidden Object
+  deriving (Generic, Show)
+
+deriveJSON' ''GeneralForumTopicUnhidden

--- a/src/Telegram/Bot/API/Types/GeneralForumTopicUnhidden.hs
+++ b/src/Telegram/Bot/API/Types/GeneralForumTopicUnhidden.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.GeneralForumTopicUnhidden where
 
-import Data.Aeson (Object)
+import Data.Aeson (FromJSON (..), ToJSON (..), Object)
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Internal.Utils
@@ -13,4 +12,5 @@ import Telegram.Bot.API.Internal.Utils
 newtype GeneralForumTopicUnhidden = GeneralForumTopicUnhidden Object
   deriving (Generic, Show)
 
-deriveJSON' ''GeneralForumTopicUnhidden
+instance ToJSON   GeneralForumTopicUnhidden where toJSON = gtoJSON
+instance FromJSON GeneralForumTopicUnhidden where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/InlineKeyboardButton.hs
+++ b/src/Telegram/Bot/API/Types/InlineKeyboardButton.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.InlineKeyboardButton where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -28,4 +28,5 @@ data InlineKeyboardButton = InlineKeyboardButton
 labeledInlineKeyboardButton :: Text -> InlineKeyboardButton
 labeledInlineKeyboardButton label = InlineKeyboardButton label Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
-deriveJSON' ''InlineKeyboardButton
+instance ToJSON   InlineKeyboardButton where toJSON = gtoJSON
+instance FromJSON InlineKeyboardButton where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/InlineKeyboardButton.hs
+++ b/src/Telegram/Bot/API/Types/InlineKeyboardButton.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.InlineKeyboardButton where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.CallbackGame
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'InlineKeyboardButton'
+
+-- | This object represents one button of an inline keyboard. You must use exactly one of the optional fields.
+data InlineKeyboardButton = InlineKeyboardButton
+  { inlineKeyboardButtonText              :: Text -- ^ Label text on the button
+  , inlineKeyboardButtonUrl               :: Maybe Text -- ^ HTTP url to be opened when button is pressed
+  , inlineKeyboardButtonCallbackData      :: Maybe Text -- ^ Data to be sent in a callback query to the bot when button is pressed, 1-64 bytes
+  , inlineKeyboardButtonWebApp            :: Maybe WebAppInfo -- ^ Description of the Web App that will be launched when the user presses the button. The Web App will be able to send an arbitrary message on behalf of the user using the method @answerWebAppQuery@. Available only in private chats between a user and the bot.
+  , inlineKeyboardButtonSwitchInlineQuery :: Maybe Text -- ^ If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot‘s username and the specified inline query in the input field. Can be empty, in which case just the bot’s username will be inserted.
+  , inlineKeyboardButtonSwitchInlineQueryCurrentChat :: Maybe Text -- ^ If set, pressing the button will insert the bot‘s username and the specified inline query in the current chat's input field. Can be empty, in which case only the bot’s username will be inserted.
+
+  , inlineKeyboardButtonCallbackGame      :: Maybe CallbackGame -- ^ Description of the game that will be launched when the user presses the button.
+  , inlineKeyboardButtonPay               :: Maybe Bool -- ^ Specify True, to send a Pay button.
+  }
+  deriving (Generic, Show)
+
+labeledInlineKeyboardButton :: Text -> InlineKeyboardButton
+labeledInlineKeyboardButton label = InlineKeyboardButton label Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+
+deriveJSON' ''InlineKeyboardButton

--- a/src/Telegram/Bot/API/Types/InlineKeyboardMarkup.hs
+++ b/src/Telegram/Bot/API/Types/InlineKeyboardMarkup.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.InlineKeyboardMarkup where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.InlineKeyboardButton
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'InlineKeyboardMarkup'
+
+-- | This object represents an inline keyboard that appears
+-- right next to the message it belongs to.
+data InlineKeyboardMarkup = InlineKeyboardMarkup
+  { inlineKeyboardMarkupInlineKeyboard :: [[InlineKeyboardButton]] -- ^ Array of button rows, each represented by an Array of InlineKeyboardButton objects
+  }
+  deriving (Generic, Show)
+
+-- ^ 
+-- **Note**: This will only work in Telegram versions released after 9 April, 2016. Older clients will display unsupported message.
+
+deriveJSON' ''InlineKeyboardMarkup

--- a/src/Telegram/Bot/API/Types/InlineKeyboardMarkup.hs
+++ b/src/Telegram/Bot/API/Types/InlineKeyboardMarkup.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.InlineKeyboardMarkup where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.InlineKeyboardButton
@@ -19,4 +19,5 @@ data InlineKeyboardMarkup = InlineKeyboardMarkup
 -- ^ 
 -- **Note**: This will only work in Telegram versions released after 9 April, 2016. Older clients will display unsupported message.
 
-deriveJSON' ''InlineKeyboardMarkup
+instance ToJSON   InlineKeyboardMarkup where toJSON = gtoJSON
+instance FromJSON InlineKeyboardMarkup where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/InputMedia.hs
+++ b/src/Telegram/Bot/API/Types/InputMedia.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.InputMedia where
 
 import Data.Aeson (ToJSON (..), KeyValue ((.=)))

--- a/src/Telegram/Bot/API/Types/InputMedia.hs
+++ b/src/Telegram/Bot/API/Types/InputMedia.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.InputMedia where
+
+import Data.Aeson (ToJSON (..), KeyValue ((.=)))
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Bool (bool)
+import Data.Maybe (catMaybes)
+import Data.Functor ((<&>))
+import Data.Text (Text, pack)
+import GHC.Generics (Generic)
+import Servant.Multipart.API
+import System.FilePath
+
+import qualified Data.Text.Lazy as TL
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.MessageEntity
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'InputMedia'
+
+-- | Generic fields for all InputMedia structures
+data InputMediaGeneric = InputMediaGeneric
+  { inputMediaGenericMedia :: InputFile -- ^ File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
+  , inputMediaGenericCaption :: Maybe Text -- ^ Caption of the photo to be sent, 0-1024 characters after entities parsing.
+  , inputMediaGenericParseMode :: Maybe Text -- ^ Mode for parsing entities in the photo caption. See formatting options <https:\/\/core.telegram.org\/bots\/api#formatting-options> for more details.
+  , inputMediaGenericCaptionEntities :: Maybe [MessageEntity] -- ^ List of special entities that appear in the caption, which can be specified instead of parse_mode.
+  }
+  deriving Generic
+
+instance ToJSON InputMediaGeneric where toJSON = gtoJSON
+
+instance ToMultipart Tmp InputMediaGeneric where
+  toMultipart InputMediaGeneric{..} = makeFile "media" inputMediaGenericMedia (MultipartData fields []) where
+    fields = catMaybes
+      [ inputMediaGenericCaption <&>
+        \t -> Input "caption" t
+      , inputMediaGenericParseMode <&>
+        \t -> Input "parse_mode" t
+      , inputMediaGenericCaptionEntities <&>
+        \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
+      ]
+
+data InputMediaGenericThumb = InputMediaGenericThumb
+  { inputMediaGenericGeneric :: InputMediaGeneric
+  , inputMediaGenericThumb :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. 
+  }
+
+instance ToJSON InputMediaGenericThumb where
+  toJSON InputMediaGenericThumb{..}
+    = addJsonFields (toJSON inputMediaGenericGeneric)
+      ["thumb" .= inputMediaGenericThumb]
+
+instance ToMultipart Tmp InputMediaGenericThumb where
+  toMultipart = \case
+    InputMediaGenericThumb generic Nothing -> toMultipart generic
+    InputMediaGenericThumb generic (Just thumb) -> makeFile "thumb" thumb (toMultipart generic)
+
+
+data InputMedia
+  = InputMediaPhoto -- ^ Represents a photo to be sent.
+    { inputMediaPhotoGeneric :: InputMediaGeneric
+    , inputMediaPhotoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
+    }
+  | InputMediaVideo -- ^ Represents a video to be sent.
+    { inputMediaVideoGeneric :: InputMediaGenericThumb
+    , inputMediaVideoWidth :: Maybe Integer -- ^ Video width
+    , inputMediaVideoHeight :: Maybe Integer -- ^ Video height
+    , inputMediaVideoDuration :: Maybe Integer -- ^ Video duration in seconds
+    , inputMediaVideoSupportsStreaming :: Maybe Bool -- ^ Pass 'True', if the uploaded video is suitable for streaming.
+    , inputMediaVideoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
+    }
+  | InputMediaAnimation -- ^ Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.
+    { inputMediaAnimationGeneric :: InputMediaGenericThumb
+    , inputMediaAnimationWidth :: Maybe Integer -- ^ Animation width
+    , inputMediaAnimationHeight :: Maybe Integer -- ^ Animation height
+    , inputMediaAnimationDuration :: Maybe Integer -- ^ Animation duration in seconds
+    , inputMediaAnimationHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
+    }
+  | InputMediaAudio -- ^ Represents an audio file to be treated as music to be sent.
+    { inputMediaAudioGeneric :: InputMediaGenericThumb
+    , inputMediaAudioDuration :: Maybe Integer -- ^ Duration of the audio in seconds
+    , inputMediaAudioPerformer :: Maybe Text -- ^ Performer of the audio
+    , inputMediaAudioTitle :: Maybe Text -- ^ Title of the audio
+    }
+  | InputMediaDocument -- ^ Represents a general file to be sent.
+    { inputMediaDocumentGeneric :: InputMediaGenericThumb
+    , inputMediaDocumentDisableContentTypeDetection :: Maybe Bool -- ^ Disables automatic server-side content type detection for files uploaded using multipart/form-data. Always True, if the document is sent as part of an album.
+    }
+
+instance ToJSON InputMedia where
+  toJSON = \case
+    InputMediaPhoto img spoiler ->
+      addJsonFields (toJSON img) (addType "photo" [ "has_spoiler" .= spoiler])
+    InputMediaVideo imgt width height duration streaming spoiler ->
+      addJsonFields (toJSON imgt)
+                (addType "video"
+                [ "width" .= width
+                , "height" .= height
+                , "duration" .= duration
+                , "support_streaming" .= streaming
+                , "has_spoiler" .= spoiler
+                ])
+    InputMediaAnimation imgt width height duration spoiler ->
+      addJsonFields (toJSON imgt)
+                (addType "animation"
+                [ "width" .= width
+                , "height" .= height
+                , "duration" .= duration
+                , "has_spoiler" .= spoiler
+                ])
+    InputMediaAudio imgt duration performer title ->
+      addJsonFields (toJSON imgt)
+                (addType "audio"
+                [ "duration" .= duration
+                , "performer" .= performer
+                , "title" .= title
+                ])
+    InputMediaDocument imgt dctd ->
+      addJsonFields (toJSON imgt)
+                (addType "document" ["disable_content_type_detection" .= dctd])
+
+
+
+instance ToMultipart Tmp InputMedia where
+  toMultipart = let
+    in \case
+    InputMediaPhoto img spoiler ->
+      addMultipartFields
+      (Input "type" "photo"
+       : catMaybes
+        [ spoiler <&>
+          \t -> Input "has_spoiler" (bool "false" "true" t)
+        ]) (toMultipart img)
+    InputMediaVideo imgt width height duration streaming spoiler ->
+      addMultipartFields
+      (Input "type" "video"
+      : catMaybes 
+      [ width <&>
+        \t -> Input "width" (TL.toStrict $ encodeToLazyText t)
+      , height <&>
+        \t -> Input "height" (TL.toStrict $ encodeToLazyText t)
+      , duration <&>
+        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
+      , streaming <&>
+        \t -> Input "support_streaming" (bool "false" "true" t)
+      , spoiler <&>
+        \t -> Input "has_spoiler" (bool "false" "true" t)
+      ]) (toMultipart imgt)
+    InputMediaAnimation imgt width height duration spoiler ->
+      addMultipartFields
+      (Input "type" "animation"
+      : catMaybes 
+      [ width <&>
+        \t -> Input "width" (TL.toStrict $ encodeToLazyText t)
+      , height <&>
+        \t -> Input "height" (TL.toStrict $ encodeToLazyText t)
+      , duration <&>
+        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
+      , spoiler <&>
+        \t -> Input "has_spoiler" (bool "false" "true" t)
+      ]) (toMultipart imgt)
+    InputMediaAudio imgt duration performer title ->
+      addMultipartFields
+      (Input "type" "audio"
+      : catMaybes 
+      [ duration <&>
+        \t -> Input "duration" (TL.toStrict $ encodeToLazyText t)
+      , performer <&>
+        \t -> Input "performer" t
+      , title <&>
+        \t -> Input "title" t
+      ]) (toMultipart imgt)
+    InputMediaDocument imgt dctd ->
+      addMultipartFields
+      (Input "type" "document"
+      : catMaybes 
+      [ dctd <&> 
+         \t -> Input "disable_content_type_detection" (bool "false" "true" t)
+      ]) (toMultipart imgt)
+
+type ContentType = Text
+
+data InputFile
+  = InputFileId FileId
+  | FileUrl Text
+  | InputFile FilePath ContentType
+
+instance ToJSON InputFile where
+  toJSON (InputFileId i) = toJSON i
+  toJSON (FileUrl t) = toJSON t
+  toJSON (InputFile f _) = toJSON ("attach://" <> pack (takeFileName f))
+
+
+-- | Multipart file helper
+makeFile :: Text -> InputFile ->  MultipartData Tmp ->  MultipartData Tmp
+makeFile name (InputFile path ct) (MultipartData fields files) = 
+  MultipartData 
+    (Input name ("attach://" <> name) : fields) 
+    (FileData name (pack $ takeFileName path) ct path : files)
+
+makeFile name file (MultipartData fields files) = 
+  MultipartData 
+    (Input name (TL.toStrict $ encodeToLazyText file) : fields) 
+    files

--- a/src/Telegram/Bot/API/Types/Invoice.hs
+++ b/src/Telegram/Bot/API/Types/Invoice.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Invoice where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Invoice'
+
+-- | This object contains basic information about an invoice.
+data Invoice = Invoice
+  { invoiceTitle          :: Text  -- ^ Product name.
+  , invoiceDescription    :: Text  -- ^ Product description.
+  , invoiceStartParameter :: Text  -- ^ Unique bot deep-linking parameter that can be used to generate this invoice.
+  , invoiceCurrency       :: Text  -- ^ Three-letter ISO 4217 currency code.
+  , invoiceTotalAmount    :: Int -- ^ Total price in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Invoice

--- a/src/Telegram/Bot/API/Types/Invoice.hs
+++ b/src/Telegram/Bot/API/Types/Invoice.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Invoice where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -19,4 +19,5 @@ data Invoice = Invoice
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Invoice
+instance ToJSON   Invoice where toJSON = gtoJSON
+instance FromJSON Invoice where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/KeyboardButton.hs
+++ b/src/Telegram/Bot/API/Types/KeyboardButton.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.KeyboardButton where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.String
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -31,4 +31,5 @@ data KeyboardButton = KeyboardButton
 instance IsString KeyboardButton where
   fromString s = KeyboardButton (fromString s) Nothing Nothing Nothing Nothing Nothing Nothing
 
-deriveJSON' ''KeyboardButton
+instance ToJSON   KeyboardButton where toJSON = gtoJSON
+instance FromJSON KeyboardButton where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/KeyboardButton.hs
+++ b/src/Telegram/Bot/API/Types/KeyboardButton.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.KeyboardButton where
+
+import Data.String
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.KeyboardButtonRequestChat
+import Telegram.Bot.API.Types.KeyboardButtonRequestUser
+import Telegram.Bot.API.Types.PollType
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'KeyboardButton'
+
+-- | This object represents one button of the reply keyboard.
+-- For simple text buttons String can be used instead of this object
+-- to specify text of the button. Optional fields are mutually exclusive.
+data KeyboardButton = KeyboardButton
+  { keyboardButtonText            :: Text       -- ^ Text of the button. If none of the optional fields are used, it will be sent as a message when the button is pressed.
+  , keyboardButtonRequestUser     :: Maybe KeyboardButtonRequestUser -- ^ If specified, pressing the button will open a list of suitable users. Tapping on any user will send their identifier to the bot in a “user_shared” service message. Available in private chats only.
+  , keyboardButtonRequestChat     :: Maybe KeyboardButtonRequestChat -- ^ If specified, pressing the button will open a list of suitable chats. Tapping on a chat will send its identifier to the bot in a “chat_shared” service message. Available in private chats only.
+  , keyboardButtonRequestContact  :: Maybe Bool -- ^ If 'True', the user's phone number will be sent as a contact when the button is pressed. Available in private chats only.
+  , keyboardButtonRequestLocation :: Maybe Bool -- ^ If 'True', the user's current location will be sent when the button is pressed. Available in private chats only.
+  , keyboardButtonRequestPoll     :: Maybe PollType -- ^ If specified, the user will be asked to create a poll and send it to the bot when the button is pressed. Available in private chats only.
+  , keyboardButtonWebApp          :: Maybe WebAppInfo -- ^ If specified, the described Web App will be launched when the button is pressed. The Web App will be able to send a “web_app_data” service message. Available in private chats only.
+  }
+  deriving (Generic, Show)
+
+instance IsString KeyboardButton where
+  fromString s = KeyboardButton (fromString s) Nothing Nothing Nothing Nothing Nothing Nothing
+
+deriveJSON' ''KeyboardButton

--- a/src/Telegram/Bot/API/Types/KeyboardButtonRequestChat.hs
+++ b/src/Telegram/Bot/API/Types/KeyboardButtonRequestChat.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.KeyboardButtonRequestChat where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.ChatAdministratorRights
@@ -23,4 +23,5 @@ data KeyboardButtonRequestChat = KeyboardButtonRequestChat
   }
   deriving (Generic, Show)
 
-deriveJSON' ''KeyboardButtonRequestChat
+instance ToJSON   KeyboardButtonRequestChat where toJSON = gtoJSON
+instance FromJSON KeyboardButtonRequestChat where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/KeyboardButtonRequestChat.hs
+++ b/src/Telegram/Bot/API/Types/KeyboardButtonRequestChat.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.KeyboardButtonRequestChat where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.ChatAdministratorRights
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'KeyboardButtonRequestChat'
+
+-- | This object defines the criteria used to request a suitable chat. The identifier of the selected chat will be shared with the bot when the corresponding button is pressed.
+data KeyboardButtonRequestChat = KeyboardButtonRequestChat
+  { keyboardButtonRequestChatRequestId :: RequestId -- ^ Signed 32-bit identifier of the request, which will be received back in the 'ChatShared' object. Must be unique within the message
+  , keyboardButtonRequestChatChatIsChannel :: Bool -- ^ Pass 'True' to request a channel chat, pass 'False' to request a group or a supergroup chat. 
+  , keyboardButtonRequestChatChatIsForum :: Maybe Bool -- ^ Pass 'True' to request a forum supergroup, pass 'False' to request a non-forum chat. If not specified, no additional restrictions are applied.
+  , keyboardButtonRequestChatChatHasUsername :: Maybe Bool -- ^ Pass 'True' to request a supergroup or a channel with a username, pass 'False' to request a chat without a username. If not specified, no additional restrictions are applied.
+  , keyboardButtonRequestChatChatIsCreated :: Maybe Bool -- ^ Pass 'True' to request a chat owned by the user. Otherwise, no additional restrictions are applied.
+  , keyboardButtonRequestChatUserAdministratorRights :: Maybe ChatAdministratorRights -- ^ A JSON-serialized object listing the required administrator rights of the user in the chat. The rights must be a superset of @bot_administrator_rights@. If not specified, no additional restrictions are applied.
+  , keyboardButtonRequestChatBotAdministratorRights :: Maybe ChatAdministratorRights -- ^ A JSON-serialized object listing the required administrator rights of the bot in the chat. The rights must be a subset of @user_administrator_rights@. If not specified, no additional restrictions are applied.
+  , keyboardButtonRequestChatBotIsMember :: Maybe Bool -- ^ Pass 'True' to request a chat with the bot as a member. Otherwise, no additional restrictions are applied.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''KeyboardButtonRequestChat

--- a/src/Telegram/Bot/API/Types/KeyboardButtonRequestUser.hs
+++ b/src/Telegram/Bot/API/Types/KeyboardButtonRequestUser.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.KeyboardButtonRequestUser where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'KeyboardButtonRequestUser'
+
+-- | This object defines the criteria used to request a suitable user. The identifier of the selected user will be shared with the bot when the corresponding button is pressed.
+data KeyboardButtonRequestUser = KeyboardButtonRequestUser
+  { keyboardButtonRequestUserRequestId :: RequestId -- ^ Signed 32-bit identifier of the request, which will be received back in the 'UserShared' object. Must be unique within the message
+  , keyboardButtonRequestUserUserIsBot :: Maybe Bool -- ^ Pass 'True' to request a bot, pass 'False' to request a regular user. If not specified, no additional restrictions are applied.
+  , keyboardButtonRequestUserUserIsPremium :: Maybe Bool -- ^ Pass 'True' to request a premium user, pass 'False' to request a non-premium user. If not specified, no additional restrictions are applied.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''KeyboardButtonRequestUser

--- a/src/Telegram/Bot/API/Types/KeyboardButtonRequestUser.hs
+++ b/src/Telegram/Bot/API/Types/KeyboardButtonRequestUser.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.KeyboardButtonRequestUser where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -17,4 +17,5 @@ data KeyboardButtonRequestUser = KeyboardButtonRequestUser
   }
   deriving (Generic, Show)
 
-deriveJSON' ''KeyboardButtonRequestUser
+instance ToJSON   KeyboardButtonRequestUser where toJSON = gtoJSON
+instance FromJSON KeyboardButtonRequestUser where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/LabeledPrice.hs
+++ b/src/Telegram/Bot/API/Types/LabeledPrice.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.LabeledPrice where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -16,4 +16,5 @@ data LabeledPrice = LabelPrice
   }
   deriving (Generic, Show)
 
-deriveJSON' ''LabeledPrice
+instance ToJSON   LabeledPrice where toJSON = gtoJSON
+instance FromJSON LabeledPrice where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/LabeledPrice.hs
+++ b/src/Telegram/Bot/API/Types/LabeledPrice.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.LabeledPrice where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'LabeledPrice'
+
+-- | This object represents a portion of the price for goods or services.
+data LabeledPrice = LabelPrice
+  { labeledPriceLabel  :: Text  -- ^ Portion label.
+  , labeledPriceAmount :: Int -- ^ Price of the product in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''LabeledPrice

--- a/src/Telegram/Bot/API/Types/Location.hs
+++ b/src/Telegram/Bot/API/Types/Location.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Location where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -20,4 +20,5 @@ data Location = Location
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Location
+instance ToJSON   Location where toJSON = gtoJSON
+instance FromJSON Location where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Location.hs
+++ b/src/Telegram/Bot/API/Types/Location.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Location where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** Location
+
+-- | This object represents a point on the map.
+data Location = Location
+  { locationLongitude            :: Float         -- ^ Longitude as defined by sender.
+  , locationLatitude             :: Float         -- ^ Latitude as defined by sender.
+  , locationHorizontalAccuracy   :: Maybe Float   -- ^ The radius of uncertainty for the location, measured in meters; 0-1500.
+  , locationLivePeriod           :: Maybe Seconds -- ^ Time relative to the message sending date, during which the location can be updated; in seconds. For active live locations only.
+  , locationHeading              :: Maybe Int     -- ^ The direction in which user is moving, in degrees; 1-360. For active live locations only.
+  , locationProximityAlertRadius :: Maybe Int     -- ^ Maximum distance for proximity alerts about approaching another chat member, in meters. For sent live locations only.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Location

--- a/src/Telegram/Bot/API/Types/LoginUrl.hs
+++ b/src/Telegram/Bot/API/Types/LoginUrl.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.LoginUrl where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'LoginUrl'
+
+-- | This object represents a parameter of the inline keyboard button used to automatically authorize a user. Serves as a great replacement for the Telegram Login Widget when the user is coming from Telegram. All the user needs to do is tap/click a button and confirm that they want to log in:
+--
+-- https://core.telegram.org/file/811140015/1734/8VZFkwWXalM.97872/6127fa62d8a0bf2b3c
+--
+-- Telegram apps support these buttons as of version 5.7.
+data LoginUrl = LoginUrl
+  { loginUrlUrl                :: Text       -- ^ An HTTP URL to be opened with user authorization data added to the query string when the button is pressed. If the user refuses to provide authorization data, the original URL without information about the user will be opened. The data added is the same as described in Receiving authorization data.
+  --
+  -- **NOTE**: You **must** always check the hash of the received data to verify the authentication and the integrity of the data as described in Checking authorization.
+  , loginUrlForwardText        :: Maybe Text -- ^ New text of the button in forwarded messages.
+  , loginUrlBotUsername        :: Maybe Text -- ^ Username of a bot, which will be used for user authorization. See Setting up a bot for more details. If not specified, the current bot's username will be assumed. The url's domain must be the same as the domain linked with the bot. See Linking your domain to the bot for more details.
+  , loginUrlRequestWriteAccess :: Maybe Bool -- ^ Pass 'True' to request the permission for your bot to send messages to the user.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''LoginUrl

--- a/src/Telegram/Bot/API/Types/LoginUrl.hs
+++ b/src/Telegram/Bot/API/Types/LoginUrl.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.LoginUrl where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -24,4 +24,5 @@ data LoginUrl = LoginUrl
   }
   deriving (Generic, Show)
 
-deriveJSON' ''LoginUrl
+instance ToJSON   LoginUrl where toJSON = gtoJSON
+instance FromJSON LoginUrl where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/MaskPosition.hs
+++ b/src/Telegram/Bot/API/Types/MaskPosition.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.MaskPosition where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -18,4 +18,5 @@ data MaskPosition = MaskPosition
   }
   deriving (Generic, Show)
 
-deriveJSON' ''MaskPosition
+instance ToJSON   MaskPosition where toJSON = gtoJSON
+instance FromJSON MaskPosition where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/MaskPosition.hs
+++ b/src/Telegram/Bot/API/Types/MaskPosition.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.MaskPosition where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'MaskPosition'
+
+-- | This object describes the position on faces where a mask should be placed by default.
+data MaskPosition = MaskPosition
+  { maskPositionPoint  :: Text  -- ^ The part of the face relative to which the mask should be placed. One of “forehead”, “eyes”, “mouth”, or “chin”.
+  , maskPositionXShift :: Float -- ^ Shift by X-axis measured in widths of the mask scaled to the face size, from left to right. For example, choosing -1.0 will place mask just to the left of the default mask position.
+  , maskPositionYShift :: Float -- ^ Shift by Y-axis measured in heights of the mask scaled to the face size, from top to bottom. For example, 1.0 will place the mask just below the default mask position.
+  , maskPositionScale  :: Float -- ^ Mask scaling coefficient. For example, 2.0 means double size.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''MaskPosition

--- a/src/Telegram/Bot/API/Types/MenuButton.hs
+++ b/src/Telegram/Bot/API/Types/MenuButton.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Telegram.Bot.API.Types.MenuButton where
+
+import Data.Aeson (KeyValue ((.=)), FromJSON (..), ToJSON (..), object)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'MenuButton'
+
+-- | This object describes the bot's menu button in a private chat.
+-- If a menu button other than @MenuButtonDefault@ is set for a private chat, then it is applied in the chat. Otherwise the default menu button is applied. By default, the menu button opens the list of bot commands.
+data MenuButton
+  = MenuButtonCommands -- ^ Represents a menu button, which opens the bot's list of commands.
+  | MenuButtonWebApp -- ^ Represents a menu button, which launches a Web App.
+      { menuButtonWebAppText :: Text
+      , menuButtonWebAppWebApp :: WebAppInfo
+      } 
+  | MenuButtonDefault -- ^ Describes that no specific value for the menu button was set.
+  deriving Generic
+
+instance ToJSON MenuButton where
+  toJSON = \case
+    MenuButtonCommands ->
+      object $ addType "commands" []
+    MenuButtonWebApp txt wai ->
+      object $ addType "web_app" ["text" .= txt, "web_app_info" .= wai]
+    MenuButtonDefault ->
+      object $ addType "default" []
+
+instance FromJSON MenuButton where
+  parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Message.hs
+++ b/src/Telegram/Bot/API/Types/Message.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Message where
+
+import Data.Text (Text)
+import Data.Time.Clock.POSIX (POSIXTime)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Animation
+import Telegram.Bot.API.Types.Audio
+import Telegram.Bot.API.Types.Document
+import {-# SOURCE #-} Telegram.Bot.API.Types.Chat
+import Telegram.Bot.API.Types.ChatShared
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.Contact
+import Telegram.Bot.API.Types.Dice
+import Telegram.Bot.API.Types.ForumTopicEdited
+import Telegram.Bot.API.Types.ForumTopicClosed
+import Telegram.Bot.API.Types.ForumTopicCreated
+import Telegram.Bot.API.Types.ForumTopicReopened
+import Telegram.Bot.API.Types.Game
+import Telegram.Bot.API.Types.InlineKeyboardMarkup
+import Telegram.Bot.API.Types.Invoice
+import Telegram.Bot.API.Types.Location
+import Telegram.Bot.API.Types.MessageAutoDeleteTimerChanged
+import Telegram.Bot.API.Types.MessageEntity
+import Telegram.Bot.API.Types.PassportData
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Types.Poll
+import Telegram.Bot.API.Types.ProximityAlertTriggered
+import Telegram.Bot.API.Types.Sticker
+import Telegram.Bot.API.Types.SuccessfulPayment
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Types.UserShared
+import Telegram.Bot.API.Types.Venue
+import Telegram.Bot.API.Types.Video
+import Telegram.Bot.API.Types.VideoChatEnded
+import Telegram.Bot.API.Types.VideoChatScheduled
+import Telegram.Bot.API.Types.VideoChatStarted
+import Telegram.Bot.API.Types.VideoNote
+import Telegram.Bot.API.Types.Voice
+import Telegram.Bot.API.Types.WebAppData
+import Telegram.Bot.API.Types.WriteAccessAllowed
+import Telegram.Bot.API.Internal.Utils
+
+-- ** Message
+
+-- | This object represents a message.
+data Message = Message
+  { messageMessageId             :: MessageId -- ^ Unique message identifier inside this chat.
+  , messageMessageThreadId       :: Maybe MessageThreadId -- ^ Unique identifier of a message thread to which the message belongs; for supergroups only.
+  , messageFrom                  :: Maybe User -- ^ Sender, empty for messages sent to channels.
+  , messageSenderChat            :: Maybe Chat -- ^ Sender of the message, sent on behalf of a chat. For example, the channel itself for channel posts, the supergroup itself for messages from anonymous group administrators, the linked channel for messages automatically forwarded to the discussion group. For backward compatibility, the field from contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
+  , messageDate                  :: POSIXTime -- ^ Date the message was sent in Unix time.
+  , messageChat                  :: Chat -- ^ Conversation the message belongs to.
+  , messageForwardFrom           :: Maybe User -- ^ For forwarded messages, sender of the original message.
+  , messageForwardFromChat       :: Maybe Chat -- ^ For messages forwarded from channels, information about the original channel.
+  , messageForwardFromMessageId  :: Maybe MessageId -- ^ For messages forwarded from channels, identifier of the original message in the channel.
+  , messageForwardSignature      :: Maybe Text -- ^ For messages forwarded from channels, signature of the post author if present.
+  , messageForwardSenderName     :: Maybe Text -- ^ Sender's name for messages forwarded from users who disallow adding a link to their account in forwarded messages.
+  , messageForwardDate           :: Maybe POSIXTime -- ^ For forwarded messages, date the original message was sent in Unix time
+  , messageIsTopicMessage        :: Maybe Bool -- ^ 'True', if the message is sent to a forum topic.
+  , messageIsAutomaticForward    :: Maybe Bool -- ^ 'True', if the message is a channel post that was automatically forwarded to the connected discussion group.
+  , messageReplyToMessage        :: Maybe Message -- ^ For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
+  , messageViaBot                :: Maybe User -- ^ Bot through which the message was sent.
+  , messageEditDate              :: Maybe POSIXTime -- ^ Date the message was last edited in Unix time
+  , messageHasProtectedContent   :: Maybe Bool -- ^ 'True', if the message can't be forwarded.
+  , messageMediaGroupId          :: Maybe MediaGroupId -- ^ The unique identifier of a media message group this message belongs to
+  , messageAuthorSignature       :: Maybe Text -- ^ Signature of the post author for messages in channels
+  , messageText                  :: Maybe Text -- ^ For text messages, the actual UTF-8 text of the message, 0-4096 characters.
+  , messageEntities              :: Maybe [MessageEntity] -- ^ For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text
+  , messageAnimation             :: Maybe Animation -- ^ Message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set.
+  , messageAudio                 :: Maybe Audio -- ^ Message is an audio file, information about the file
+  , messageDocument              :: Maybe Document -- ^ Message is a general file, information about the file.
+  , messagePhoto                 :: Maybe [PhotoSize] -- ^ Message is a photo, available sizes of the photo
+  , messageSticker               :: Maybe Sticker -- ^ Message is a sticker, information about the sticker
+  , messageVideo                 :: Maybe Video -- ^ Message is a video, information about the video
+  , messageVideoNote             :: Maybe VideoNote -- ^ Message is a video note, information about the video message
+  , messageVoice                 :: Maybe Voice -- ^ Message is a voice message, information about the file
+  , messageCaption               :: Maybe Text -- ^ Caption for the audio, document, photo, video or voice, 0-200 characters
+  , messageCaptionEntities       :: Maybe [MessageEntity] -- ^ For messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption.
+  , messageHasMediaSpoiler       :: Maybe Bool -- ^ 'True', if the message media is covered by a spoiler animation.
+  , messageContact               :: Maybe Contact -- ^ Message is a shared contact, information about the contact
+  , messageDice                  :: Maybe Dice -- ^ Message is a dice with random value.
+  , messageGame                  :: Maybe Game -- ^ Message is a game, information about the game. More about games »  , messageLocation              :: Maybe Location -- ^ Message is a shared location, information about the location
+  , messagePoll                  :: Maybe Poll -- ^ Message is a native poll, information about the poll.
+  , messageVenue                 :: Maybe Venue -- ^ Message is a venue, information about the venue
+  , messageLocation              :: Maybe Location -- ^ Message is a shared location, information about the location.
+  , messageNewChatMembers        :: Maybe [User] -- ^ New members that were added to the group or supergroup and information about them (the bot itself may be one of these members)
+  , messageLeftChatMember        :: Maybe User -- ^ A member was removed from the group, information about them (this member may be the bot itself)
+  , messageNewChatTitle          :: Maybe Text -- ^ A chat title was changed to this value
+  , messageNewChatPhoto          :: Maybe [PhotoSize] -- ^ A chat photo was change to this value
+  , messageDeleteChatPhoto       :: Maybe Bool -- ^ Service message: the chat photo was deleted
+  , messageGroupChatCreated      :: Maybe Bool -- ^ Service message: the group has been created
+  , messageSupergroupChatCreated :: Maybe Bool -- ^ Service message: the supergroup has been created. This field can‘t be received in a message coming through updates, because bot can’t be a member of a supergroup when it is created. It can only be found in reply_to_message if someone replies to a very first message in a directly created supergroup.
+  , messageChannelChatCreated    :: Maybe Bool -- ^ Service message: the channel has been created. This field can‘t be received in a message coming through updates, because bot can’t be a member of a channel when it is created. It can only be found in reply_to_message if someone replies to a very first message in a channel.
+  , messageAutoDeleteTimerChanged :: Maybe MessageAutoDeleteTimerChanged -- ^ Service message: auto-delete timer settings changed in the chat.
+  , messageHasAggressiveAntiSpamEnabled :: Maybe Bool -- ^ 'True', if aggressive anti-spam checks are enabled in the supergroup. The field is only available to chat administrators. Returned only in 'getChat'.
+  , messageHasHiddenMembers      :: Maybe Bool -- ^ 'True', if non-administrators can only get the list of bots and administrators in the chat. Returned only in 'getChat'.
+  , messageMigrateToChatId       :: Maybe ChatId -- ^ The group has been migrated to a supergroup with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+  , messageMigrateFromChatId     :: Maybe ChatId -- ^ The supergroup has been migrated from a group with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+  , messagePinnedMessage         :: Maybe Message -- ^ Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.
+  , messageInvoice               :: Maybe Invoice -- ^ Message is an invoice for a payment, information about the invoice.
+  , messageSuccessfulPayment     :: Maybe SuccessfulPayment -- ^ Message is a service message about a successful payment, information about the payment.
+  , messageUserShared            :: Maybe UserShared -- ^ Service message: a user was shared with the bot.
+  , messageChatShared            :: Maybe ChatShared -- ^ Service message: a chat was shared with the bot.
+  , messageConnectedWebsite      :: Maybe Text -- ^ The domain name of the website on which the user has logged in.
+  , messageWriteAccessAllowed    :: Maybe WriteAccessAllowed -- ^ Service message: the user allowed the bot added to the attachment menu to write messages.
+  , messagePassportData          :: Maybe PassportData -- ^ Telegram Passport data.
+  , messageProximityAlertTriggered :: Maybe ProximityAlertTriggered -- ^ Service message. A user in the chat triggered another user's proximity alert while sharing Live Location.
+  , messageForumTopicCreated     :: Maybe ForumTopicCreated -- ^ Service message: forum topic created.
+  , messageForumTopicEdited     :: Maybe ForumTopicEdited -- ^ Service message: forum topic edited.
+  , messageForumTopicClosed     :: Maybe ForumTopicClosed -- ^ Service message: forum topic closed.
+  , messageForumTopicReopened     :: Maybe ForumTopicReopened -- ^ Service message: forum topic reopened.
+  , messageVideoChatScheduled    :: Maybe VideoChatScheduled -- ^ Service message: video chat scheduled.
+  , messageVideoChatStarted      :: Maybe VideoChatStarted -- ^ Service message: video chat started
+  , messageVideoChatEnded        :: Maybe VideoChatEnded -- ^ Service message: video chat ended.
+  , messageVideoChatParticipantsInvited :: Maybe VideoChatParticipantsInvited -- ^ Service message: new participants invited to a video chat.
+  , messageWebAppData            :: Maybe WebAppData -- ^ Service message: data sent by a Web App.
+  , messageReplyMarkup           :: Maybe InlineKeyboardMarkup -- ^ Inline keyboard attached to the message. `login_url` buttons are represented as ordinary `url` buttons.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Message

--- a/src/Telegram/Bot/API/Types/Message.hs
+++ b/src/Telegram/Bot/API/Types/Message.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Message where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (POSIXTime)
 import GHC.Generics (Generic)
@@ -121,4 +121,5 @@ data Message = Message
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Message
+instance ToJSON   Message where toJSON = gtoJSON
+instance FromJSON Message where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/MessageAutoDeleteTimerChanged.hs
+++ b/src/Telegram/Bot/API/Types/MessageAutoDeleteTimerChanged.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.MessageAutoDeleteTimerChanged where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'MessageAutoDeleteTimerChanged'
+
+-- | This object represents a service message about a change in auto-delete timer settings.
+data MessageAutoDeleteTimerChanged = MessageAutoDeleteTimerChanged
+  { messageAutoDeleteTimerChangedMessageAutoDeleteTime :: Seconds -- ^ New auto-delete time for messages in the chat; in seconds
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''MessageAutoDeleteTimerChanged

--- a/src/Telegram/Bot/API/Types/MessageAutoDeleteTimerChanged.hs
+++ b/src/Telegram/Bot/API/Types/MessageAutoDeleteTimerChanged.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.MessageAutoDeleteTimerChanged where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -15,4 +15,5 @@ data MessageAutoDeleteTimerChanged = MessageAutoDeleteTimerChanged
   }
   deriving (Generic, Show)
 
-deriveJSON' ''MessageAutoDeleteTimerChanged
+instance ToJSON   MessageAutoDeleteTimerChanged where toJSON = gtoJSON
+instance FromJSON MessageAutoDeleteTimerChanged where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/MessageEntity.hs
+++ b/src/Telegram/Bot/API/Types/MessageEntity.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.MessageEntity where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -21,6 +21,10 @@ data MessageEntity = MessageEntity
   , messageEntityCustomEmojiId :: Maybe Text -- ^ For “custom_emoji” only, unique identifier of the custom emoji. Use @getCustomEmojiStickers@ to get full information about the sticker.
   }
   deriving (Generic, Show)
+
+instance ToJSON   MessageEntity where toJSON = gtoJSON
+instance FromJSON MessageEntity where parseJSON = gparseJSON
+
 
 -- | Type of the entity. Can be mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text), underline (underlined text), strikethrough, code (monowidth string), pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames), cashtag, phone_number
 data MessageEntityType
@@ -43,7 +47,5 @@ data MessageEntityType
   | MessageEntityCustomEmoji
   deriving (Eq, Show, Generic)
 
-foldMap deriveJSON'
-  [ ''MessageEntityType
-  , ''MessageEntity
-  ]
+instance ToJSON   MessageEntityType where toJSON = gtoJSON
+instance FromJSON MessageEntityType where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/MessageEntity.hs
+++ b/src/Telegram/Bot/API/Types/MessageEntity.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.MessageEntity where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** MessageEntity
+
+-- | This object represents one special entity in a text message. For example, hashtags, usernames, URLs, etc.
+data MessageEntity = MessageEntity
+  { messageEntityType   :: MessageEntityType -- ^ Type of the entity. Can be mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text), underline (underlined text), strikethrough, code (monowidth string), pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames)
+  , messageEntityOffset :: Int -- ^ Offset in UTF-16 code units to the start of the entity
+  , messageEntityLength :: Int -- ^ Length of the entity in UTF-16 code units
+  , messageEntityUrl    :: Maybe Text -- ^ For “text_link” only, url that will be opened after user taps on the text
+  , messageEntityUser   :: Maybe User -- ^ For “text_mention” only, the mentioned user
+  , messageEntityLanguage :: Maybe Text -- ^ For “pre” only, the programming language of the entity text.
+  , messageEntityCustomEmojiId :: Maybe Text -- ^ For “custom_emoji” only, unique identifier of the custom emoji. Use @getCustomEmojiStickers@ to get full information about the sticker.
+  }
+  deriving (Generic, Show)
+
+-- | Type of the entity. Can be mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text), underline (underlined text), strikethrough, code (monowidth string), pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames), cashtag, phone_number
+data MessageEntityType
+  = MessageEntityMention
+  | MessageEntityHashtag
+  | MessageEntityBotCommand
+  | MessageEntityUrl
+  | MessageEntityEmail
+  | MessageEntityBold
+  | MessageEntityItalic
+  | MessageEntityUnderline -- ^ See <https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_underline.html>
+  | MessageEntityStrikethrough -- ^ See <https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_strikethrough.html>
+  | MessageEntityCode
+  | MessageEntityPre
+  | MessageEntityTextLink
+  | MessageEntityTextMention
+  | MessageEntityCashtag -- ^ See <https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_cashtag.html>.
+  | MessageEntityPhoneNumber -- ^ See <https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_phone_number.html>.
+  | MessageEntitySpoiler
+  | MessageEntityCustomEmoji
+  deriving (Eq, Show, Generic)
+
+foldMap deriveJSON'
+  [ ''MessageEntityType
+  , ''MessageEntity
+  ]

--- a/src/Telegram/Bot/API/Types/OrderInfo.hs
+++ b/src/Telegram/Bot/API/Types/OrderInfo.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.OrderInfo where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.ShippingAddress
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'OrderInfo'
+
+-- | This object represents information about an order.
+data OrderInfo = OrderInfo
+  { orderInfoName            :: Maybe Text            -- ^ User name.
+  , orderInfoPhoneNumber     :: Maybe Text            -- ^ User's phone number.
+  , orderInfoEmail           :: Maybe Text            -- ^ User email.
+  , orderInfoShippingAddress :: Maybe ShippingAddress -- ^ User shipping address.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''OrderInfo

--- a/src/Telegram/Bot/API/Types/OrderInfo.hs
+++ b/src/Telegram/Bot/API/Types/OrderInfo.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.OrderInfo where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -19,4 +19,5 @@ data OrderInfo = OrderInfo
   }
   deriving (Generic, Show)
 
-deriveJSON' ''OrderInfo
+instance ToJSON   OrderInfo where toJSON = gtoJSON
+instance FromJSON OrderInfo where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ParseMode.hs
+++ b/src/Telegram/Bot/API/Types/ParseMode.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Telegram.Bot.API.Types.ParseMode where
+
+import Data.Aeson
+import GHC.Generics (Generic)
+
+data ParseMode
+  = Markdown
+  | HTML
+  | MarkdownV2
+  deriving (Generic)
+
+instance ToJSON   ParseMode
+instance FromJSON ParseMode

--- a/src/Telegram/Bot/API/Types/PassportData.hs
+++ b/src/Telegram/Bot/API/Types/PassportData.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.PassportData where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.EncryptedCredentials
@@ -17,4 +17,5 @@ data PassportData = PassportData
   }
   deriving (Generic, Show)
 
-deriveJSON' ''PassportData
+instance ToJSON   PassportData where toJSON = gtoJSON
+instance FromJSON PassportData where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/PassportData.hs
+++ b/src/Telegram/Bot/API/Types/PassportData.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.PassportData where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.EncryptedCredentials
+import Telegram.Bot.API.Types.EncryptedPassportElement
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'PassportData'
+
+-- | Contains information about Telegram Passport data shared with the bot by the user.
+data PassportData = PassportData
+  { passportDataData        :: [EncryptedPassportElement] -- ^ Array with information about documents and other Telegram Passport elements that was shared with the bot.
+  , passportDataCredentials :: EncryptedCredentials       -- ^ Encrypted credentials required to decrypt the data.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''PassportData

--- a/src/Telegram/Bot/API/Types/PassportElementError.hs
+++ b/src/Telegram/Bot/API/Types/PassportElementError.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.PassportElementError where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Aeson.Text (encodeToLazyText)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -27,6 +27,9 @@ data PassportErrorSource
   | PassportErrorSourceUnspecified
   deriving (Generic, Show)
 
+instance ToJSON   PassportErrorSource where toJSON = gtoJSON
+instance FromJSON PassportErrorSource where parseJSON = gparseJSON
+
 data PassportElementError
   = PassportElementError
     { passportElementErroSource       :: PassportErrorSource -- ^ Error source, must be one of 'PassportErrorSource'.
@@ -46,7 +49,5 @@ instance ToHttpApiData PassportElementError where
 instance ToHttpApiData [PassportElementError] where
   toUrlPiece = TL.toStrict . encodeToLazyText
 
-foldMap deriveJSON'
-  [ ''PassportErrorSource
-  , ''PassportElementError
-  ]
+instance ToJSON   PassportElementError where toJSON = gtoJSON
+instance FromJSON PassportElementError where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/PassportElementError.hs
+++ b/src/Telegram/Bot/API/Types/PassportElementError.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.PassportElementError where
+
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Servant.API (ToHttpApiData (..))
+
+import qualified Data.Text.Lazy as TL
+
+import Telegram.Bot.API.Types.EncryptedPassportElement
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'PassportElementError'
+
+data PassportErrorSource
+  = PassportErrorSourceData
+  | PassportErrorSourceFrontSide
+  | PassportErrorSourceReverseSide
+  | PassportErrorSourceSelfie
+  | PassportErrorSourceFile
+  | PassportErrorSourceFiles
+  | PassportErrorSourceTranslationFile
+  | PassportErrorSourceTranslationFiles
+  | PassportErrorSourceUnspecified
+  deriving (Generic, Show)
+
+data PassportElementError
+  = PassportElementError
+    { passportElementErroSource       :: PassportErrorSource -- ^ Error source, must be one of 'PassportErrorSource'.
+    , passportElementErrorType        :: PassportElementType -- ^ The section of the user's Telegram Passport which has the error, one of 'PassportElementType'.
+    , passportElementErrorName        :: Text                -- ^ Name of the data field which has the error.
+    , passportElementErrorHash        :: Maybe Text          -- ^ Base64-encoded data hash.
+    , passportElementErrorMessage     :: Text                -- ^ Error message.
+    , passportElementErrorFileHash    :: Maybe Text          -- ^ Base64-encoded hash of the file with the reverse side of the document.
+    , passportElementErrorFileHashes  :: Maybe [Text]        -- ^ List of base64-encoded file hashes.
+    , passportElementErrorElementHash :: Maybe Text          -- ^ Base64-encoded element hash.
+    }
+    deriving (Generic, Show)
+
+instance ToHttpApiData PassportElementError where
+  toUrlPiece = TL.toStrict . encodeToLazyText
+
+instance ToHttpApiData [PassportElementError] where
+  toUrlPiece = TL.toStrict . encodeToLazyText
+
+foldMap deriveJSON'
+  [ ''PassportErrorSource
+  , ''PassportElementError
+  ]

--- a/src/Telegram/Bot/API/Types/PassportFile.hs
+++ b/src/Telegram/Bot/API/Types/PassportFile.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.PassportFile where
+
+import Data.Time.Clock.POSIX (POSIXTime)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'PassportFile'
+
+-- | This object represents a file uploaded to Telegram Passport. Currently all Telegram Passport files are in JPEG format when decrypted and don't exceed 10MB.
+data PassportFile = PassportFile
+  { passportFileFileId       :: FileId    -- ^ Identifier for this file, which can be used to download or reuse the file.
+  , passportFileFileUniqueId :: FileId    -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , passportFileFileSize     :: Int     -- ^ File size in bytes.
+  , passportFileFileDate     :: POSIXTime -- ^ Unix time when the file was uploaded.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''PassportFile

--- a/src/Telegram/Bot/API/Types/PassportFile.hs
+++ b/src/Telegram/Bot/API/Types/PassportFile.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.PassportFile where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Time.Clock.POSIX (POSIXTime)
 import GHC.Generics (Generic)
 
@@ -19,4 +19,5 @@ data PassportFile = PassportFile
   }
   deriving (Generic, Show)
 
-deriveJSON' ''PassportFile
+instance ToJSON   PassportFile where toJSON = gtoJSON
+instance FromJSON PassportFile where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/PhotoSize.hs
+++ b/src/Telegram/Bot/API/Types/PhotoSize.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.PhotoSize where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -19,4 +19,5 @@ data PhotoSize = PhotoSize
   }
   deriving (Generic, Show)
 
-deriveJSON' ''PhotoSize
+instance ToJSON   PhotoSize where toJSON = gtoJSON
+instance FromJSON PhotoSize where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/PhotoSize.hs
+++ b/src/Telegram/Bot/API/Types/PhotoSize.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.PhotoSize where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'PhotoSize'
+
+-- | This object represents one size of a photo or a file / sticker thumbnail.
+data PhotoSize = PhotoSize
+  { photoSizeFileId       :: FileId      -- ^ Unique identifier for this file.
+  , photoSizeFileUniqueId :: FileId      -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , photoSizeWidth        :: Int       -- ^ Photo width
+  , photoSizeHeight       :: Int       -- ^ Photo height
+  , photoSizeFileSize     :: Maybe Int -- ^ File size
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''PhotoSize

--- a/src/Telegram/Bot/API/Types/Poll.hs
+++ b/src/Telegram/Bot/API/Types/Poll.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Poll where
+
+import Data.Text (Text)
+import Data.Time.Clock.POSIX (POSIXTime)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.MessageEntity
+import Telegram.Bot.API.Types.PollOption
+import Telegram.Bot.API.Types.PollType
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Poll'
+
+data Poll = Poll
+  { pollId                    :: PollId                -- ^ Unique poll identifier.
+  , pollQuestion              :: Text                  -- ^ Poll question, 1-300 characters.
+  , pollOptions               :: [PollOption]          -- ^ List of poll options.
+  , pollTotalVoterCount       :: Int                 -- ^ Total number of users that voted in the poll.
+  , pollIsClosed              :: Bool                  -- ^ 'True', if the poll is closed.
+  , pollIsAnonymous           :: Bool                  -- ^ 'True', if the poll is anonymous.
+  , pollType                  :: PollType              -- ^ Poll type, currently can be “regular” or “quiz”.
+  , pollAllowsMultipleAnswers :: Bool                  -- ^ 'True', if the poll allows multiple answers.
+  , pollCorrectOptionId       :: Maybe Int             -- ^ 0-based identifier of the correct answer option. Available only for polls in the quiz mode, which are closed, or was sent (not forwarded) by the bot or to the private chat with the bot.
+  , pollExplanation           :: Maybe Text            -- ^ Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters.
+  , pollExplanationEntities   :: Maybe [MessageEntity] -- ^ Special entities like usernames, URLs, bot commands, etc. that appear in the explanation.
+  , pollOpenPeriod            :: Maybe Seconds         -- ^ Amount of time in seconds the poll will be active after creation.
+  , pollCloseData             :: Maybe POSIXTime       -- ^ Point in time (Unix timestamp) when the poll will be automatically closed.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Poll

--- a/src/Telegram/Bot/API/Types/Poll.hs
+++ b/src/Telegram/Bot/API/Types/Poll.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Poll where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (POSIXTime)
 import GHC.Generics (Generic)
@@ -31,4 +31,5 @@ data Poll = Poll
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Poll
+instance ToJSON   Poll where toJSON = gtoJSON
+instance FromJSON Poll where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/PollAnswer.hs
+++ b/src/Telegram/Bot/API/Types/PollAnswer.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.PollAnswer where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'PollAnswer'
+
+-- | This object represents an answer of a user in a non-anonymous poll.
+data PollAnswer = PollAnswer
+  { pollAnswerPollId    :: PollId -- ^ Unique poll identifier.
+  , pollAnswerUser      :: User   -- ^ The user, who changed the answer to the poll.
+  , pollAnswerOptionIds :: [Int]  -- ^ 0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''PollAnswer

--- a/src/Telegram/Bot/API/Types/PollAnswer.hs
+++ b/src/Telegram/Bot/API/Types/PollAnswer.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.PollAnswer where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -18,4 +18,5 @@ data PollAnswer = PollAnswer
   }
   deriving (Generic, Show)
 
-deriveJSON' ''PollAnswer
+instance ToJSON   PollAnswer where toJSON = gtoJSON
+instance FromJSON PollAnswer where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/PollOption.hs
+++ b/src/Telegram/Bot/API/Types/PollOption.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.PollOption where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'PollOption'
+
+-- | This object contains information about one answer option in a poll.
+data PollOption = PollOption
+  { pollOptionText       :: Text -- ^ Option text, 1-100 characters.
+  , pollOptionVoterCount :: Int  -- ^ Number of users that voted for this option.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''PollOption

--- a/src/Telegram/Bot/API/Types/PollOption.hs
+++ b/src/Telegram/Bot/API/Types/PollOption.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.PollOption where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -16,4 +16,5 @@ data PollOption = PollOption
   }
   deriving (Generic, Show)
 
-deriveJSON' ''PollOption
+instance ToJSON   PollOption where toJSON = gtoJSON
+instance FromJSON PollOption where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/PollType.hs
+++ b/src/Telegram/Bot/API/Types/PollType.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.PollType where
+
+import Data.Aeson (Value(String), FromJSON (..), ToJSON (..))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'PollType'
+
+data PollType =
+  PollTypeQuiz | PollTypeRegular
+  deriving (Generic, Show)
+
+getPollType :: PollType -> Text
+getPollType PollTypeQuiz = "quiz"
+getPollType PollTypeRegular = "regular"
+
+instance ToJSON PollType where
+  toJSON = String . getPollType
+
+instance FromJSON PollType where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/PollType.hs
+++ b/src/Telegram/Bot/API/Types/PollType.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.PollType where
 
 import Data.Aeson (Value(String), FromJSON (..), ToJSON (..))

--- a/src/Telegram/Bot/API/Types/PreCheckoutQuery.hs
+++ b/src/Telegram/Bot/API/Types/PreCheckoutQuery.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.PreCheckoutQuery where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -24,4 +24,5 @@ data PreCheckoutQuery = PreCheckoutQuery
   }
   deriving (Generic, Show)
 
-deriveJSON' ''PreCheckoutQuery
+instance ToJSON   PreCheckoutQuery where toJSON = gtoJSON
+instance FromJSON PreCheckoutQuery where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/PreCheckoutQuery.hs
+++ b/src/Telegram/Bot/API/Types/PreCheckoutQuery.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.PreCheckoutQuery where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.OrderInfo
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'PreCheckoutQuery'
+
+-- | This object contains information about an incoming pre-checkout query.
+data PreCheckoutQuery = PreCheckoutQuery
+  { preCheckoutQueryId               :: Text                   -- ^ Unique query identifier.
+  , preCheckoutQueryFrom             :: User                   -- ^ User who sent the query.
+  , preCheckoutQueryCurrency         :: Text                   -- ^ Three-letter ISO 4217 currency code
+  , preCheckoutQueryTotalAmount      :: Int                  -- ^ Total price in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
+  , preCheckoutQueryInvoicePayload   :: Text                   -- ^ Bot specified invoice payload
+  , preCheckoutQueryShippingOptionId :: Maybe ShippingOptionId -- ^ Identifier of the shipping option chosen by the user.
+  , preCheckoutQueryOrderInfo        :: Maybe OrderInfo        -- ^ Order info provided by the user.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''PreCheckoutQuery

--- a/src/Telegram/Bot/API/Types/ProximityAlertTriggered.hs
+++ b/src/Telegram/Bot/API/Types/ProximityAlertTriggered.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ProximityAlertTriggered where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ProximityAlertTriggered'
+
+-- | This object represents the content of a service message, sent whenever a user in the chat triggers a proximity alert set by another user.
+data ProximityAlertTriggered = ProximityAlertTriggered
+  { proximityAlertTriggeredTraveler :: User  -- ^ User that triggered the alert.
+  , proximityAlertTriggeredWatcher  :: User  -- ^ User that set the alert.
+  , proximityAlertTriggeredDistance :: Int -- ^ The distance between the users.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ProximityAlertTriggered

--- a/src/Telegram/Bot/API/Types/ProximityAlertTriggered.hs
+++ b/src/Telegram/Bot/API/Types/ProximityAlertTriggered.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ProximityAlertTriggered where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.User
@@ -17,4 +17,5 @@ data ProximityAlertTriggered = ProximityAlertTriggered
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ProximityAlertTriggered
+instance ToJSON   ProximityAlertTriggered where toJSON = gtoJSON
+instance FromJSON ProximityAlertTriggered where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ReplyKeyboardMarkup.hs
+++ b/src/Telegram/Bot/API/Types/ReplyKeyboardMarkup.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ReplyKeyboardMarkup where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -23,4 +23,5 @@ data ReplyKeyboardMarkup = ReplyKeyboardMarkup
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ReplyKeyboardMarkup
+instance ToJSON   ReplyKeyboardMarkup where toJSON = gtoJSON
+instance FromJSON ReplyKeyboardMarkup where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ReplyKeyboardMarkup.hs
+++ b/src/Telegram/Bot/API/Types/ReplyKeyboardMarkup.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ReplyKeyboardMarkup where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.KeyboardButton
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ReplyKeyboardMarkup'
+
+-- | This object represents a custom keyboard with reply options (see Introduction to bots for details and examples).
+data ReplyKeyboardMarkup = ReplyKeyboardMarkup
+  { replyKeyboardMarkupKeyboard           :: [[KeyboardButton]] -- ^ Array of button rows, each represented by an Array of KeyboardButton objects.
+  , replyKeyboardMarkupIsPersistent      :: Maybe Bool         -- ^ Requests clients to always show the keyboard when the regular keyboard is hidden. Defaults to 'False', in which case the custom keyboard can be hidden and opened with a keyboard icon.
+  , replyKeyboardMarkupResizeKeyboard     :: Maybe Bool         -- ^ Requests clients to resize the keyboard vertically for optimal fit (e.g., make the keyboard smaller if there are just two rows of buttons). Defaults to false, in which case the custom keyboard is always of the same height as the app's standard keyboard.
+  , replyKeyboardMarkupOneTimeKeyboard    :: Maybe Bool         -- ^ Requests clients to hide the keyboard as soon as it's been used. The keyboard will still be available, but clients will automatically display the usual letter-keyboard in the chat – the user can press a special button in the input field to see the custom keyboard again. Defaults to false.
+  , replyKeyboardMarkupInputFieldSelector :: Maybe Text         -- ^ The placeholder to be shown in the input field when the keyboard is active; 1-64 characters.
+  , replyKeyboardMarkupSelective          :: Maybe Bool         -- ^ Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
+    --
+    -- Example: A user requests to change the bot's language, bot replies to the request with a keyboard to select the new language. Other users in the group don't see the keyboard.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ReplyKeyboardMarkup

--- a/src/Telegram/Bot/API/Types/ReplyKeyboardRemove.hs
+++ b/src/Telegram/Bot/API/Types/ReplyKeyboardRemove.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ReplyKeyboardRemove where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ReplyKeyboardRemove'
+
+-- | Upon receiving a message with this object,
+-- Telegram clients will remove the current custom keyboard
+-- and display the default letter-keyboard.
+--
+-- By default, custom keyboards are displayed until a new keyboard is sent by a bot.
+-- An exception is made for one-time keyboards that are hidden immediately after
+-- the user presses a button (see 'ReplyKeyboardMarkup').
+data ReplyKeyboardRemove = ReplyKeyboardRemove
+  { replyKeyboardRemoveRemoveKeyboard :: Bool -- ^ Requests clients to remove the custom keyboard (user will not be able to summon this keyboard; if you want to hide the keyboard from sight but keep it accessible, use one_time_keyboard in ReplyKeyboardMarkup)
+  , replyKeyboardRemoveSelective      :: Maybe Bool -- ^ Use this parameter if you want to remove the keyboard for specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
+  --
+  -- Example: A user votes in a poll, bot returns confirmation message in reply to the vote and removes the keyboard for that user, while still showing the keyboard with poll options to users who haven't voted yet.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ReplyKeyboardRemove

--- a/src/Telegram/Bot/API/Types/ReplyKeyboardRemove.hs
+++ b/src/Telegram/Bot/API/Types/ReplyKeyboardRemove.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ReplyKeyboardRemove where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Internal.Utils
@@ -23,4 +23,5 @@ data ReplyKeyboardRemove = ReplyKeyboardRemove
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ReplyKeyboardRemove
+instance ToJSON   ReplyKeyboardRemove where toJSON = gtoJSON
+instance FromJSON ReplyKeyboardRemove where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ResponseParameters.hs
+++ b/src/Telegram/Bot/API/Types/ResponseParameters.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ResponseParameters where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -16,4 +16,5 @@ data ResponseParameters = ResponseParameters
   }
   deriving (Show, Generic)
 
-deriveJSON' ''ResponseParameters
+instance ToJSON   ResponseParameters where toJSON = gtoJSON
+instance FromJSON ResponseParameters where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ResponseParameters.hs
+++ b/src/Telegram/Bot/API/Types/ResponseParameters.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ResponseParameters where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ResponseParameters'
+
+-- | Contains information about why a request was unsuccessful.
+data ResponseParameters = ResponseParameters
+  { responseParametersMigrateToChatId :: Maybe ChatId -- ^ The group has been migrated to a supergroup with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+  , responseParametersRetryAfter      :: Maybe Seconds -- ^ In case of exceeding flood control, the number of seconds left to wait before the request can be repeated
+  }
+  deriving (Show, Generic)
+
+deriveJSON' ''ResponseParameters

--- a/src/Telegram/Bot/API/Types/ShippingAddress.hs
+++ b/src/Telegram/Bot/API/Types/ShippingAddress.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ShippingAddress where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -20,4 +20,5 @@ data ShippingAddress = ShippingAddress
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ShippingAddress
+instance ToJSON   ShippingAddress where toJSON = gtoJSON
+instance FromJSON ShippingAddress where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ShippingAddress.hs
+++ b/src/Telegram/Bot/API/Types/ShippingAddress.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ShippingAddress where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ShippingAddress'
+
+-- | This object represents a shipping address.
+data ShippingAddress = ShippingAddress
+  { shippingAddressCountryCode :: Text -- ^ ISO 3166-1 alpha-2 country code.
+  , shippingAddressState       :: Text -- ^ State, if applicable.
+  , shippingAddressCity        :: Text -- ^ City.
+  , shippingAddressStreetLine1 :: Text -- ^ First line for the address.
+  , shippingAddressStreetLine2 :: Text -- ^ Second line for the address.
+  , shippingAddressPostCode    :: Text -- ^ Address post code.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ShippingAddress

--- a/src/Telegram/Bot/API/Types/ShippingOption.hs
+++ b/src/Telegram/Bot/API/Types/ShippingOption.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ShippingOption where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -19,4 +19,5 @@ data ShippingOption = ShippingOption
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ShippingOption
+instance ToJSON   ShippingOption where toJSON = gtoJSON
+instance FromJSON ShippingOption where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/ShippingOption.hs
+++ b/src/Telegram/Bot/API/Types/ShippingOption.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ShippingOption where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.LabeledPrice
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ShippingOption'
+
+-- | This object represents one shipping option.
+data ShippingOption = ShippingOption
+  { shippingOptionId    :: ShippingOptionId -- ^ Shipping option identifier.
+  , shippingOptionTitle :: Text             -- ^ Option title.
+  , shippingOptionPrice :: [LabeledPrice]   -- ^ List of price portions.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ShippingOption

--- a/src/Telegram/Bot/API/Types/ShippingQuery.hs
+++ b/src/Telegram/Bot/API/Types/ShippingQuery.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.ShippingQuery where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.ShippingAddress
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'ShippingQuery'
+
+-- | This object contains information about an incoming shipping query.
+data ShippingQuery = ShippingQuery
+  { shippingQueryId              :: Text            -- ^ Unique query identifier.
+  , shippingQueryFrom            :: User            -- ^ User who sent the query.
+  , shippingQueryInvoicePayload  :: Text            -- ^ Bot specified invoice payload.
+  , shippingQueryShippingAddress :: ShippingAddress -- ^ User specified shipping address.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''ShippingQuery

--- a/src/Telegram/Bot/API/Types/ShippingQuery.hs
+++ b/src/Telegram/Bot/API/Types/ShippingQuery.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.ShippingQuery where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -20,4 +20,5 @@ data ShippingQuery = ShippingQuery
   }
   deriving (Generic, Show)
 
-deriveJSON' ''ShippingQuery
+instance ToJSON   ShippingQuery where toJSON = gtoJSON
+instance FromJSON ShippingQuery where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/SomeReplyMarkup.hs
+++ b/src/Telegram/Bot/API/Types/SomeReplyMarkup.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Telegram.Bot.API.Types.SomeReplyMarkup where
+
+import Data.Aeson
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.Types.ForceReply
+import Telegram.Bot.API.Types.InlineKeyboardMarkup
+import Telegram.Bot.API.Types.ReplyKeyboardMarkup
+import Telegram.Bot.API.Types.ReplyKeyboardRemove
+
+-- | Additional interface options.
+-- A JSON-serialized object for an inline keyboard, custom reply keyboard,
+-- instructions to remove reply keyboard or to force a reply from the user.
+data SomeReplyMarkup
+  = SomeInlineKeyboardMarkup InlineKeyboardMarkup
+  | SomeReplyKeyboardMarkup  ReplyKeyboardMarkup
+  | SomeReplyKeyboardRemove  ReplyKeyboardRemove
+  | SomeForceReply           ForceReply
+  deriving (Generic)
+
+instance ToJSON   SomeReplyMarkup where toJSON = genericSomeToJSON
+instance FromJSON SomeReplyMarkup where parseJSON = genericSomeParseJSON

--- a/src/Telegram/Bot/API/Types/Sticker.hs
+++ b/src/Telegram/Bot/API/Types/Sticker.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Sticker where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common 
+import Telegram.Bot.API.Types.File
+import Telegram.Bot.API.Types.MaskPosition
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Sticker'
+
+-- | This object represents a sticker.
+data Sticker = Sticker
+  { stickerFileId       :: FileId             -- ^ Identifier for this file, which can be used to download or reuse the file.
+  , stickerFileUniqueId :: FileId             -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , stickerWidth        :: Int              -- ^ Sticker width.
+  , stickerHeight       :: Int              -- ^ Sticker height.
+  , stickerIsAnimated   :: Bool               -- ^ 'True', if the sticker is animated.
+  , stickerIsVideo      :: Bool               -- ^ 'True', if the sticker is a video sticker.
+  , stickerThumb        :: Maybe PhotoSize    -- ^ Sticker thumbnail in the .WEBP or .JPG format.
+  , stickerEmoji        :: Maybe Text         -- ^ Emoji associated with the sticker.
+  , stickerSetName      :: Maybe Text         -- ^ Name of the sticker set to which the sticker belongs.
+  , stickerPremiumAnimation :: Maybe File    -- ^ For premium regular stickers, premium animation for the sticker.
+  , stickerMaskPosition :: Maybe MaskPosition -- ^ For mask stickers, the position where the mask should be placed.
+  , stickerCustomEmojiId :: Maybe Text        -- ^ For custom emoji stickers, unique identifier of the custom emoji.
+  , stickerFileSize     :: Maybe Integer      -- ^ File size in bytes.
+  }
+  deriving (Generic, Show)
+
+-- ** 'StickerSet'
+
+-- | This object represents a sticker set.
+data StickerSet = StickerSet
+  { stickerSetName          :: Text            -- ^ Sticker set name.
+  , stickerSetTitle         :: Text            -- ^ Sticker set title.
+  , stickerSetType          :: StickerSetType  -- ^ Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”.
+  , stickerSetIsAnimated    :: Bool            -- ^ 'True', if the sticker set contains animated stickers.
+  , stickerSetIsVideo       :: Bool            -- ^ 'True', if the sticker is a video sticker.
+  , stickerSetContainsMasks :: Maybe Bool      -- ^ True, if the sticker set contains masks.
+  , stickerSetStickers      :: [Sticker]       -- ^ List of all set stickers.
+  , stickerSetThumb         :: Maybe PhotoSize -- ^ Sticker set thumbnail in the .WEBP or .TGS format.
+  }
+  deriving (Generic, Show)
+
+-- | Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”.
+data StickerSetType
+  = StickerSetTypeRegular
+  | StickerSetTypeMask
+  | StickerSetTypeCustomEmoji
+  deriving (Eq, Show, Generic)
+
+foldMap deriveJSON'
+  [ ''StickerSetType
+  , ''StickerSet
+  , ''Sticker
+  ]
+

--- a/src/Telegram/Bot/API/Types/Sticker.hs
+++ b/src/Telegram/Bot/API/Types/Sticker.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Sticker where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -32,6 +32,9 @@ data Sticker = Sticker
   }
   deriving (Generic, Show)
 
+instance ToJSON   Sticker where toJSON = gtoJSON
+instance FromJSON Sticker where parseJSON = gparseJSON
+
 -- ** 'StickerSet'
 
 -- | This object represents a sticker set.
@@ -47,6 +50,10 @@ data StickerSet = StickerSet
   }
   deriving (Generic, Show)
 
+instance ToJSON   StickerSet where toJSON = gtoJSON
+instance FromJSON StickerSet where parseJSON = gparseJSON
+
+
 -- | Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”.
 data StickerSetType
   = StickerSetTypeRegular
@@ -54,9 +61,5 @@ data StickerSetType
   | StickerSetTypeCustomEmoji
   deriving (Eq, Show, Generic)
 
-foldMap deriveJSON'
-  [ ''StickerSetType
-  , ''StickerSet
-  , ''Sticker
-  ]
-
+instance ToJSON   StickerSetType where toJSON = gtoJSON
+instance FromJSON StickerSetType where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/SuccessfulPayment.hs
+++ b/src/Telegram/Bot/API/Types/SuccessfulPayment.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.SuccessfulPayment where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.OrderInfo
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'SuccessfulPayment'
+
+-- | This object contains basic information about a successful payment.
+data SuccessfulPayment = SuccessfulPayment
+  { successfulPaymentCurrency                :: Text                   -- ^ Three-letter ISO 4217 currency code.
+  , successfulPaymentTotalAmount             :: Int                  -- ^ Total price in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45 pass amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
+  , successfulPaymentInvoicePayload          :: Text                   -- ^ Bot specified invoice payload.
+  , successfulPaymentShippingOptionId        :: Maybe ShippingOptionId -- ^ Identifier of the shipping option chosen by the user.
+  , successfulPaymentOrderInfo               :: Maybe OrderInfo        -- ^ Order info provided by the user.
+  , successfulPaymentTelegramPaymentChargeId :: Text                   -- ^ Telegram payment identifier.
+  , successfulPaymentProviderPaymentChargeId :: Text                   -- ^ Provider payment identifier.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''SuccessfulPayment

--- a/src/Telegram/Bot/API/Types/SuccessfulPayment.hs
+++ b/src/Telegram/Bot/API/Types/SuccessfulPayment.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.SuccessfulPayment where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -23,4 +23,5 @@ data SuccessfulPayment = SuccessfulPayment
   }
   deriving (Generic, Show)
 
-deriveJSON' ''SuccessfulPayment
+instance ToJSON   SuccessfulPayment where toJSON = gtoJSON
+instance FromJSON SuccessfulPayment where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/User.hs
+++ b/src/Telegram/Bot/API/Types/User.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.User where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -28,4 +28,5 @@ data User = User
   }
   deriving (Show, Generic)
 
-deriveJSON' ''User
+instance ToJSON   User where toJSON = gtoJSON
+instance FromJSON User where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/User.hs
+++ b/src/Telegram/Bot/API/Types/User.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.User where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** User
+
+-- | This object represents a Telegram user or bot.
+--
+-- <https://core.telegram.org/bots/api#user>
+data User = User
+  { userId           :: UserId     -- ^ Unique identifier for this user or bot.
+  , userIsBot        :: Bool       -- ^ 'True', if this user is a bot.
+  , userFirstName    :: Text       -- ^ User's or bot's first name.
+  , userLastName     :: Maybe Text -- ^ User‘s or bot’s last name.
+  , userUsername     :: Maybe Text -- ^ User‘s or bot’s username.
+  , userLanguageCode :: Maybe Text -- ^ IETF language tag of the user's language.
+  , userIsPremium    :: Maybe Bool -- ^ 'True', if this user is a Telegram Premium user.
+  , userAddedToAttachmentMenu :: Maybe Bool -- ^ 'True', if this user added the bot to the attachment menu.
+  , userCanJoinGroups :: Maybe Bool -- ^ 'True', if the bot can be invited to groups. Returned only in `getMe`.
+  , userCanReadAllGroupMessages :: Maybe Bool -- ^ 'True', if privacy mode is disabled for the bot. Returned only in `getMe`.
+  , userSupportsInlineQueries :: Maybe Bool -- ^ 'True', if the bot supports inline queries. Returned only in `getMe`.
+  }
+  deriving (Show, Generic)
+
+deriveJSON' ''User

--- a/src/Telegram/Bot/API/Types/UserProfilePhotos.hs
+++ b/src/Telegram/Bot/API/Types/UserProfilePhotos.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.UserProfilePhotos where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'UserProfilePhotos'
+
+-- | This object represent a user's profile pictures.
+data UserProfilePhotos = UserProfilePhotos
+  { userProfilePhotosTotalCount :: Int -- ^ Total number of profile pictures the target user has
+  , userProfilePhotosPhotos     :: [[PhotoSize]] -- ^ Requested profile pictures (in up to 4 sizes each)
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''UserProfilePhotos

--- a/src/Telegram/Bot/API/Types/UserProfilePhotos.hs
+++ b/src/Telegram/Bot/API/Types/UserProfilePhotos.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.UserProfilePhotos where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.PhotoSize
@@ -16,4 +16,5 @@ data UserProfilePhotos = UserProfilePhotos
   }
   deriving (Generic, Show)
 
-deriveJSON' ''UserProfilePhotos
+instance ToJSON   UserProfilePhotos where toJSON = gtoJSON
+instance FromJSON UserProfilePhotos where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/UserShared.hs
+++ b/src/Telegram/Bot/API/Types/UserShared.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.UserShared where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -16,4 +16,5 @@ data UserShared = UserShared
   }
   deriving (Generic, Show)
 
-deriveJSON' ''UserShared
+instance ToJSON   UserShared where toJSON = gtoJSON
+instance FromJSON UserShared where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/UserShared.hs
+++ b/src/Telegram/Bot/API/Types/UserShared.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.UserShared where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'UserShared'
+
+-- | This object contains information about the user whose identifier was shared with the bot using a 'KeyboardButtonRequestUser' button.
+data UserShared = UserShared
+  { userSharedRequestId :: RequestId -- ^ Identifier of the request.
+  , userSharedUserId :: UserId -- ^ Identifier of the shared user. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''UserShared

--- a/src/Telegram/Bot/API/Types/Venue.hs
+++ b/src/Telegram/Bot/API/Types/Venue.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Venue where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -22,4 +22,5 @@ data Venue = Venue
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Venue
+instance ToJSON   Venue where toJSON = gtoJSON
+instance FromJSON Venue where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Venue.hs
+++ b/src/Telegram/Bot/API/Types/Venue.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Venue where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Location
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Venue'
+
+-- | This object represents a venue.
+data Venue = Venue
+  { venueLocation        :: Location   -- ^ Venue location.
+  , venueTitle           :: Text       -- ^ Name of the venue.
+  , venueAddress         :: Text       -- ^ Address of the venue.
+  , venueFoursquareId    :: Maybe Text -- ^ Foursquare identifier of the venue.
+  , venueFoursquareType  :: Maybe Text -- ^ Foursquare type of the venue. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+  , venueGooglePlaceId   :: Maybe Text -- ^ Google Places identifier of the venue.
+  , venueGooglePlaceType :: Maybe Text -- ^ Google Places type of the venue. (See supported types.)
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Venue

--- a/src/Telegram/Bot/API/Types/Video.hs
+++ b/src/Telegram/Bot/API/Types/Video.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Video where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common 
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Video'
+
+-- | This object represents a video file.
+data Video = Video
+  { videoFileId       :: FileId -- ^ Unique identifier for this file.
+  , videoFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , videoWidth        :: Int -- ^ Video width as defined by sender.
+  , videoHeight       :: Int -- ^ Video height as defined by sender.
+  , videoDuration     :: Seconds -- ^ Duration of the video in seconds as defined by sender.
+  , videoThumb        :: Maybe PhotoSize -- ^ Video thumbnail.
+  , videoFileName     :: Maybe Text -- ^ Original filename as defined by sender.
+  , videoMimeType     :: Maybe Text -- ^ Mime type of a file as defined by sender.
+  , videoFileSize     :: Maybe Integer -- ^ File size in bytes.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Video

--- a/src/Telegram/Bot/API/Types/Video.hs
+++ b/src/Telegram/Bot/API/Types/Video.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Video where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -25,4 +25,5 @@ data Video = Video
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Video
+instance ToJSON   Video where toJSON = gtoJSON
+instance FromJSON Video where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/VideoChatEnded.hs
+++ b/src/Telegram/Bot/API/Types/VideoChatEnded.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.VideoChatEnded where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common
+import Telegram.Bot.API.Types.User
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'VideoChatEnded'
+
+-- | This object represents a service message about a video chat ended in the chat.
+data VideoChatEnded = VideoChatEnded
+  { videoChatEndedDuration :: Seconds -- ^ Video chat duration in seconds.
+  }
+  deriving (Generic, Show)
+
+-- ** 'VideoChatParticipantsInvited'
+data VideoChatParticipantsInvited = VideoChatParticipantsInvited
+  { videoChatParticipantsInvitedUsers :: Maybe [User] -- ^ New members that were invited to the video chat.
+  }
+  deriving (Generic, Show)
+
+foldMap deriveJSON'
+  [ ''VideoChatEnded
+  , ''VideoChatParticipantsInvited
+  ]

--- a/src/Telegram/Bot/API/Types/VideoChatEnded.hs
+++ b/src/Telegram/Bot/API/Types/VideoChatEnded.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.VideoChatEnded where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common
@@ -16,13 +16,16 @@ data VideoChatEnded = VideoChatEnded
   }
   deriving (Generic, Show)
 
+instance ToJSON   VideoChatEnded where toJSON = gtoJSON
+instance FromJSON VideoChatEnded where parseJSON = gparseJSON
+
+
 -- ** 'VideoChatParticipantsInvited'
+
 data VideoChatParticipantsInvited = VideoChatParticipantsInvited
   { videoChatParticipantsInvitedUsers :: Maybe [User] -- ^ New members that were invited to the video chat.
   }
   deriving (Generic, Show)
 
-foldMap deriveJSON'
-  [ ''VideoChatEnded
-  , ''VideoChatParticipantsInvited
-  ]
+instance ToJSON   VideoChatParticipantsInvited where toJSON = gtoJSON
+instance FromJSON VideoChatParticipantsInvited where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/VideoChatScheduled.hs
+++ b/src/Telegram/Bot/API/Types/VideoChatScheduled.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.VideoChatScheduled where
+
+import Data.Time.Clock.POSIX (POSIXTime)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'VideoChatScheduled'
+
+-- | This object represents a service message about a video chat scheduled in the chat.
+data VideoChatScheduled = VideoChatScheduled
+  { videoChatScheduledStartDate :: POSIXTime -- ^ Point in time (Unix timestamp) when the video chat is supposed to be started by a chat administrator.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''VideoChatScheduled

--- a/src/Telegram/Bot/API/Types/VideoChatScheduled.hs
+++ b/src/Telegram/Bot/API/Types/VideoChatScheduled.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.VideoChatScheduled where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Time.Clock.POSIX (POSIXTime)
 import GHC.Generics (Generic)
 
@@ -15,4 +15,5 @@ data VideoChatScheduled = VideoChatScheduled
   }
   deriving (Generic, Show)
 
-deriveJSON' ''VideoChatScheduled
+instance ToJSON   VideoChatScheduled where toJSON = gtoJSON
+instance FromJSON VideoChatScheduled where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/VideoChatStarted.hs
+++ b/src/Telegram/Bot/API/Types/VideoChatStarted.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.VideoChatStarted where
 
 import Data.Aeson

--- a/src/Telegram/Bot/API/Types/VideoChatStarted.hs
+++ b/src/Telegram/Bot/API/Types/VideoChatStarted.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.VideoChatStarted where
+
+import Data.Aeson
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'VideoChatStarted'
+
+-- | This object represents a service message about a video chat started in the chat. Currently holds no information.
+data VideoChatStarted = VideoChatStarted
+  deriving (Generic, Show)
+
+instance ToJSON VideoChatStarted where
+  toJSON = gtoJSON
+
+instance FromJSON VideoChatStarted where
+  parseJSON (Object _) = pure VideoChatStarted
+  parseJSON _ = fail "Unable to parse VideoChatStarted: expected an empty object"

--- a/src/Telegram/Bot/API/Types/VideoNote.hs
+++ b/src/Telegram/Bot/API/Types/VideoNote.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.VideoNote where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common 
@@ -21,4 +21,5 @@ data VideoNote = VideoNote
   }
   deriving (Generic, Show)
 
-deriveJSON' ''VideoNote
+instance ToJSON   VideoNote where toJSON = gtoJSON
+instance FromJSON VideoNote where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/VideoNote.hs
+++ b/src/Telegram/Bot/API/Types/VideoNote.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.VideoNote where
+
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common 
+import Telegram.Bot.API.Types.PhotoSize
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'VideoNote'
+
+-- | This object represents a video message (available in Telegram apps as of v.4.0).
+data VideoNote = VideoNote
+  { videoNoteFileId   :: FileId -- ^ Unique identifier for this file.
+  , videoNoteFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , videoNoteLength   :: Int -- ^ Video width and height as defined by sender.
+  , videoNoteDuration :: Seconds -- ^ Duration of the video in seconds as defined by sender.
+  , videoNoteThumb    :: Maybe PhotoSize -- ^ Video thumbnail.
+  , videoNoteFileSize :: Maybe Integer -- ^ File size in bytes.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''VideoNote

--- a/src/Telegram/Bot/API/Types/Voice.hs
+++ b/src/Telegram/Bot/API/Types/Voice.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.Voice where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -20,4 +20,5 @@ data Voice = Voice
   }
   deriving (Generic, Show)
 
-deriveJSON' ''Voice
+instance ToJSON   Voice where toJSON = gtoJSON
+instance FromJSON Voice where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/Voice.hs
+++ b/src/Telegram/Bot/API/Types/Voice.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.Voice where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Types.Common 
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'Voice'
+
+-- | This object represents a voice note.
+data Voice = Voice
+  { voiceFileId   :: FileId -- ^ Unique identifier for this file.
+  , voiceFileUniqueId :: FileId -- ^ Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+  , voiceDuration :: Seconds -- ^ Duration of the audio in seconds as defined by sender.
+  , voiceMimeType :: Maybe Text -- ^ MIME type of the file as defined by sender.
+  , voiceFileSize :: Maybe Integer -- ^ File size in bytes.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''Voice

--- a/src/Telegram/Bot/API/Types/WebAppData.hs
+++ b/src/Telegram/Bot/API/Types/WebAppData.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.WebAppData where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -15,4 +15,5 @@ data WebAppData = WebAppData
   }
   deriving (Generic, Show)
 
-deriveJSON' ''WebAppData
+instance ToJSON   WebAppData where toJSON = gtoJSON
+instance FromJSON WebAppData where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/WebAppData.hs
+++ b/src/Telegram/Bot/API/Types/WebAppData.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.WebAppData where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'WebAppData'
+
+data WebAppData = WebAppData
+  { webAppDataData       :: Text -- ^ The data. Be aware that a bad client can send arbitrary data in this field.
+  , webAppDataButtonText :: Text -- ^ Text of the @web_app@ keyboard button, from which the Web App was opened. Be aware that a bad client can send arbitrary data in this field.
+  }
+  deriving (Generic, Show)
+
+deriveJSON' ''WebAppData

--- a/src/Telegram/Bot/API/Types/WriteAccessAllowed.hs
+++ b/src/Telegram/Bot/API/Types/WriteAccessAllowed.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Telegram.Bot.API.Types.WriteAccessAllowed where
 
-import Data.Aeson (Object)
+import Data.Aeson (FromJSON (..), ToJSON (..), Object)
 import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Internal.Utils
@@ -13,4 +12,5 @@ import Telegram.Bot.API.Internal.Utils
 newtype WriteAccessAllowed = WriteAccessAllowed Object
   deriving (Generic, Show)
 
-deriveJSON' ''WriteAccessAllowed
+instance ToJSON   WriteAccessAllowed where toJSON = gtoJSON
+instance FromJSON WriteAccessAllowed where parseJSON = gparseJSON

--- a/src/Telegram/Bot/API/Types/WriteAccessAllowed.hs
+++ b/src/Telegram/Bot/API/Types/WriteAccessAllowed.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Telegram.Bot.API.Types.WriteAccessAllowed where
+
+import Data.Aeson (Object)
+import GHC.Generics (Generic)
+
+import Telegram.Bot.API.Internal.Utils
+
+-- ** 'WriteAccessAllowed'
+
+-- | This object represents a service message about a user allowing a bot added to the attachment menu to write messages. Currently holds no information.
+newtype WriteAccessAllowed = WriteAccessAllowed Object
+  deriving (Generic, Show)
+
+deriveJSON' ''WriteAccessAllowed

--- a/src/Telegram/Bot/API/WebApps.hs
+++ b/src/Telegram/Bot/API/WebApps.hs
@@ -23,8 +23,8 @@ import Telegram.Bot.API.InlineMode.InlineQueryResult (InlineQueryResult)
 -- ** 'AnswerWebAppQueryRequest'
 
 data AnswerWebAppQueryRequest = AnswerWebAppQueryRequest
-  { answerWebAppQueryRequestWebAppQueryId :: Text              -- ^ Unique identifier for the query to be answered.
-  , answerWebAppQueryRequestResult        :: InlineQueryResult -- ^ A JSON-serialized object describing the message to be sent.
+  { answerWebAppQueryWebAppQueryId :: Text              -- ^ Unique identifier for the query to be answered.
+  , answerWebAppQueryResult        :: InlineQueryResult -- ^ A JSON-serialized object describing the message to be sent.
   }
   deriving (Generic, Show)
 

--- a/telegram-bot-simple.cabal
+++ b/telegram-bot-simple.cabal
@@ -32,6 +32,7 @@ flag examples
 
 library
   exposed-modules:
+      -- API
       Telegram.Bot.API
       Telegram.Bot.API.Chat
       Telegram.Bot.API.Forum
@@ -42,14 +43,159 @@ library
       Telegram.Bot.API.InlineMode.InputMessageContent
       Telegram.Bot.API.Internal.Utils
       Telegram.Bot.API.MakingRequests
+      -- Methods
       Telegram.Bot.API.Methods
+      Telegram.Bot.API.Methods.AnswerCallbackQuery
+      Telegram.Bot.API.Methods.ApproveChatJoinRequest
+      Telegram.Bot.API.Methods.BanChatMember
+      Telegram.Bot.API.Methods.BanChatSenderChat
+      Telegram.Bot.API.Methods.CopyMessage
+      Telegram.Bot.API.Methods.CreateChatInviteLink
+      Telegram.Bot.API.Methods.DeclineChatJoinRequest
+      Telegram.Bot.API.Methods.DeleteChatPhoto
+      Telegram.Bot.API.Methods.DeleteChatStickerSet
+      Telegram.Bot.API.Methods.DeleteMessage
+      Telegram.Bot.API.Methods.DeleteMyCommands
+      Telegram.Bot.API.Methods.EditChatInviteLink
+      Telegram.Bot.API.Methods.EditMessageLiveLocation
+      Telegram.Bot.API.Methods.ExportChatInviteLink
+      Telegram.Bot.API.Methods.ForwardMessage
+      Telegram.Bot.API.Methods.GetChat
+      Telegram.Bot.API.Methods.GetChatAdministrators
+      Telegram.Bot.API.Methods.GetChatMember
+      Telegram.Bot.API.Methods.GetChatMemberCount
+      Telegram.Bot.API.Methods.GetChatMenuButton
+      Telegram.Bot.API.Methods.GetFile
+      Telegram.Bot.API.Methods.GetMe
+      Telegram.Bot.API.Methods.GetMyCommands
+      Telegram.Bot.API.Methods.GetMyDefaultAdministratorRights
+      Telegram.Bot.API.Methods.GetUserProfilePhotos
+      Telegram.Bot.API.Methods.LeaveChat
+      Telegram.Bot.API.Methods.PinChatMessage
+      Telegram.Bot.API.Methods.PromoteChatMember
+      Telegram.Bot.API.Methods.RestrictChatMember
+      Telegram.Bot.API.Methods.RevokeChatInviteLink
+      Telegram.Bot.API.Methods.SendAnimation
+      Telegram.Bot.API.Methods.SendAudio
+      Telegram.Bot.API.Methods.SendChatAction
+      Telegram.Bot.API.Methods.SendContact
+      Telegram.Bot.API.Methods.SendDice
+      Telegram.Bot.API.Methods.SendDocument
+      Telegram.Bot.API.Methods.SendLocation
+      Telegram.Bot.API.Methods.SendMediaGroup
+      Telegram.Bot.API.Methods.SendMessage
+      Telegram.Bot.API.Methods.SendPhoto
+      Telegram.Bot.API.Methods.SendPoll
+      Telegram.Bot.API.Methods.SendVenue
+      Telegram.Bot.API.Methods.SendVideo
+      Telegram.Bot.API.Methods.SendVideoNote
+      Telegram.Bot.API.Methods.SendVoice
+      Telegram.Bot.API.Methods.SetChatAdministratorCustomTitle
+      Telegram.Bot.API.Methods.SetChatDescription
+      Telegram.Bot.API.Methods.SetChatMenuButton
+      Telegram.Bot.API.Methods.SetChatPermissions
+      Telegram.Bot.API.Methods.SetChatPhoto
+      Telegram.Bot.API.Methods.SetChatStickerSet
+      Telegram.Bot.API.Methods.SetChatTitle
+      Telegram.Bot.API.Methods.SetMyCommands
+      Telegram.Bot.API.Methods.SetMyDefaultAdministratorRights
+      Telegram.Bot.API.Methods.StopMessageLiveLocation
+      Telegram.Bot.API.Methods.UnbanChatMember
+      Telegram.Bot.API.Methods.UnbanChatSenderChat
+      Telegram.Bot.API.Methods.UnpinAllChatMessages
+      Telegram.Bot.API.Methods.UnpinChatMessage
+
       Telegram.Bot.API.Passport
       Telegram.Bot.API.Payments
       Telegram.Bot.API.Stickers
       Telegram.Bot.API.Types
+      -- Types
+      Telegram.Bot.API.Types.Animation
+      Telegram.Bot.API.Types.Audio
+      Telegram.Bot.API.Types.BotCommand
+      Telegram.Bot.API.Types.BotCommandScope
+      Telegram.Bot.API.Types.CallbackGame
+      Telegram.Bot.API.Types.CallbackQuery
+      Telegram.Bot.API.Types.Chat
+      Telegram.Bot.API.Types.ChatAdministratorRights
+      Telegram.Bot.API.Types.ChatInviteLink
+      Telegram.Bot.API.Types.ChatJoinRequest
+      Telegram.Bot.API.Types.ChatLocation
+      Telegram.Bot.API.Types.ChatMember
+      Telegram.Bot.API.Types.ChatMemberUpdated
+      Telegram.Bot.API.Types.ChatPermissions
+      Telegram.Bot.API.Types.ChatPhoto
+      Telegram.Bot.API.Types.ChatShared
+      Telegram.Bot.API.Types.Common
+      Telegram.Bot.API.Types.Contact
+      Telegram.Bot.API.Types.CopyMessageId
+      Telegram.Bot.API.Types.Dice
+      Telegram.Bot.API.Types.Document
+      Telegram.Bot.API.Types.EncryptedCredentials
+      Telegram.Bot.API.Types.EncryptedPassportElement
+      Telegram.Bot.API.Types.File
+      Telegram.Bot.API.Types.ForceReply
+      Telegram.Bot.API.Types.ForumTopic
+      Telegram.Bot.API.Types.ForumTopicEdited
+      Telegram.Bot.API.Types.ForumTopicClosed
+      Telegram.Bot.API.Types.ForumTopicCreated
+      Telegram.Bot.API.Types.ForumTopicReopened
+      Telegram.Bot.API.Types.Game
+      Telegram.Bot.API.Types.GameHighScore
+      Telegram.Bot.API.Types.GeneralForumTopicHidden
+      Telegram.Bot.API.Types.GeneralForumTopicUnhidden
+      Telegram.Bot.API.Types.InlineKeyboardButton
+      Telegram.Bot.API.Types.InlineKeyboardMarkup
+      Telegram.Bot.API.Types.InputMedia
+      Telegram.Bot.API.Types.Invoice
+      Telegram.Bot.API.Types.KeyboardButton
+      Telegram.Bot.API.Types.KeyboardButtonRequestChat
+      Telegram.Bot.API.Types.KeyboardButtonRequestUser
+      Telegram.Bot.API.Types.LabeledPrice
+      Telegram.Bot.API.Types.Location
+      Telegram.Bot.API.Types.LoginUrl
+      Telegram.Bot.API.Types.MaskPosition
+      Telegram.Bot.API.Types.MenuButton
+      Telegram.Bot.API.Types.Message
+      Telegram.Bot.API.Types.MessageAutoDeleteTimerChanged
+      Telegram.Bot.API.Types.MessageEntity
+      Telegram.Bot.API.Types.OrderInfo
+      Telegram.Bot.API.Types.ParseMode
+      Telegram.Bot.API.Types.PassportData
+      Telegram.Bot.API.Types.PassportElementError
+      Telegram.Bot.API.Types.PassportFile
+      Telegram.Bot.API.Types.PhotoSize
+      Telegram.Bot.API.Types.Poll
+      Telegram.Bot.API.Types.PollAnswer
+      Telegram.Bot.API.Types.PollOption
+      Telegram.Bot.API.Types.PollType
+      Telegram.Bot.API.Types.PreCheckoutQuery
+      Telegram.Bot.API.Types.ProximityAlertTriggered
+      Telegram.Bot.API.Types.ReplyKeyboardMarkup
+      Telegram.Bot.API.Types.ReplyKeyboardRemove
+      Telegram.Bot.API.Types.ResponseParameters
+      Telegram.Bot.API.Types.ShippingAddress
+      Telegram.Bot.API.Types.ShippingOption
+      Telegram.Bot.API.Types.ShippingQuery
+      Telegram.Bot.API.Types.SomeReplyMarkup
+      Telegram.Bot.API.Types.Sticker
+      Telegram.Bot.API.Types.SuccessfulPayment
+      Telegram.Bot.API.Types.User
+      Telegram.Bot.API.Types.UserProfilePhotos
+      Telegram.Bot.API.Types.UserShared
+      Telegram.Bot.API.Types.Venue
+      Telegram.Bot.API.Types.Video
+      Telegram.Bot.API.Types.VideoChatEnded
+      Telegram.Bot.API.Types.VideoChatScheduled
+      Telegram.Bot.API.Types.VideoChatStarted
+      Telegram.Bot.API.Types.VideoNote
+      Telegram.Bot.API.Types.Voice
+      Telegram.Bot.API.Types.WebAppData
+      Telegram.Bot.API.Types.WriteAccessAllowed
       Telegram.Bot.API.UpdatingMessages
       Telegram.Bot.API.WebApps
       Telegram.Bot.API.Webhook
+      -- Telegram Bot Simple
       Telegram.Bot.Simple
       Telegram.Bot.Simple.BotApp
       Telegram.Bot.Simple.BotApp.Internal


### PR DESCRIPTION
- Split `Telegram.Bot.API.Types`,
- Split `Telegram.Bot.API.Methods`,
- Remove `Request` from field names of request types.