### PR TITLE
add flake for cabal

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ If you are building with stack then use `stack build --flag telegram-bot-simple:
 Contributions are welcome!
 Feel free to ping me on GitHub, file an issue or submit a PR :)
 
+### Nix
+
+You can use a [Nix flake](https://nixos.wiki/wiki/Flakes) from this repo to get several development tools.
+
+1. [Enable flakes](https://nixos.wiki/wiki/Flakes#Enable_flakes).
+
+2. Run `nix develop`. This command will make available `cabal`, `ghc`, and `haskell-language-server`.
+
+3. Run `cabal run example-echo-bot` to start a bot.
+
 ## Compatibility
 
 | telegram-bot-api  | telegram-bot-simple |

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,5 @@
 packages:
   telegram-bot-api/
   telegram-bot-simple/
+
+flags: +examples

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1681184417,
+        "narHash": "sha256-hEYKxuO9gQkeCdyhgvH/Jhs2bkAFyUBALCFiaT5IQE0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1fb781f4a148c19e9da1d35a4cbe15d0158afc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1fb781f4a148c19e9da1d35a4cbe15d0158afc4e",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,8 @@
         # ghc should go before haskell-language-server - https://github.com/NixOS/nixpkgs/issues/225895
         ghc
         hpkgs.haskell-language-server
+
+        pkgs.dhall-lsp-server
       ];
 
       devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils/cfacdce06f30d2b68473a46042957675eebb3401";
+    nixpkgs.url = "github:NixOS/nixpkgs/1fb781f4a148c19e9da1d35a4cbe15d0158afc4e";
+  };
+  outputs = inputs: inputs.flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = inputs.nixpkgs.legacyPackages.${system};
+
+      telegram-bot-api = "telegram-bot-api";
+      telegram-bot-simple = "telegram-bot-simple";
+
+      systemDepends = [ pkgs.zlib ];
+      override = {
+        overrides = self: super:
+          let inherit (pkgs.haskell.lib) overrideCabal; in
+          {
+            "${telegram-bot-api}" = overrideCabal
+              (super.callCabal2nix telegram-bot-api ./${telegram-bot-api} { })
+              (x: { librarySystemDepends = systemDepends ++ (x.librarySystemDepends or [ ]); });
+            "${telegram-bot-simple}" = overrideCabal
+              (self.callCabal2nix telegram-bot-simple ./${telegram-bot-simple} {
+                "${telegram-bot-api}" = self."${telegram-bot-api}";
+              })
+              (x: { librarySystemDepends = systemDepends ++ (x.librarySystemDepends or [ ]); });
+          };
+      };
+
+      ghcVersion = "ghc927";
+      hpkgs = pkgs.haskell.packages.${ghcVersion};
+
+      getHaskellPackagesDeps = packages_:
+        with pkgs.lib.lists; pkgs.lib.lists.unique (
+          subtractLists packages_ (
+            concatLists (map
+              (package:
+                __filter pkgs.lib.attrsets.isDerivation (concatLists (
+                  __attrValues package.getCabalDeps
+                )))
+              packages_)
+          )
+        );
+
+      ghcForPackages = hpkgs_:  override_: packageNames_:
+        (hpkgs_.override override_).ghcWithPackages (ps:
+          getHaskellPackagesDeps (map (x: ps.${x}) packageNames_)
+        );
+
+      ghc = ghcForPackages hpkgs override [ telegram-bot-api telegram-bot-simple ];
+
+      tools = [
+        hpkgs.cabal-install
+        # ghc should go before haskell-language-server - https://github.com/NixOS/nixpkgs/issues/225895
+        ghc
+        hpkgs.haskell-language-server
+      ];
+
+      devShells.default = pkgs.mkShell {
+        buildInputs = tools;
+        shellHook = "export LANG=C.utf8";
+      };
+    in
+    {
+      inherit devShells;
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
 
       overridePkg = self: name: localDeps: {
         "${name}" = pkgs.haskell.lib.overrideCabal
-          (self.callCabal2nix name ./${name} (__listToAttrs (map (x: { name = x; value = self.${x}; }) localDeps)))
+          (self.callCabal2nix name ./${name} (__foldl' (x: y: x // { "${y}" = self.${y}; }) { } localDeps))
           (x: { librarySystemDepends = systemDepends ++ (x.librarySystemDepends or [ ]); });
       };
 


### PR DESCRIPTION
This flake provides a devshell with `cabal` and `HLS` for GHC 9.2.5.

It's a shortened version of this [flake template](https://github.com/deemp/flakes/tree/main/templates/codium/haskell-simple#readme) for Haskell projects.