### PR TITLE
Support all inline query results and thumbnails

### DIFF
--- a/telegram-bot-api/src/Telegram/Bot/API/InlineMode/InlineQueryResult.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/InlineMode/InlineQueryResult.hs
@@ -1,82 +1,434 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
 module Telegram.Bot.API.InlineMode.InlineQueryResult where
 
-import           Data.Aeson                      (FromJSON (..), ToJSON (..), Value (String))
+import           Data.Aeson
+                 ( FromJSON (..), ToJSON (..), KeyValue ((.=)), Value (..)
+                 , withObject, (.:), (.:?)
+                 )
+import           Data.Aeson.Types (Parser)
 import           Data.Hashable                   (Hashable)
 import           Data.Text                       (Text)
 import           GHC.Generics                    (Generic)
 
 import           Telegram.Bot.API.Internal.Utils
-import           Telegram.Bot.API.Types (Contact)
+import           Telegram.Bot.API.Types
 import           Telegram.Bot.API.InlineMode.InputMessageContent
-import Telegram.Bot.API.Internal.TH (makeDefault)
+import           Telegram.Bot.API.Internal.TH (makeDefault)
 
--- | This object represents one result of an inline query
-data InlineQueryResult = InlineQueryResult
-  { inlineQueryResultType :: InlineQueryResultType -- ^ Type of the result
-  , inlineQueryResultId :: InlineQueryResultId -- ^ Unique identifier for this result, 1-64 Bytes
-  , inlineQueryResultTitle :: Maybe Text -- ^ Title of the result (only valid for "Article", "Photo", "Gif", "Mpeg4Gif", "Video", "Audio", "Voice", "Document", "Location", "Venue", "CachedPhoto", "CachedGif", "CachedMpeg4Gif", "CachedDocument", "CachedVideo", "CachedVoice" types of results)
-  , inlineQueryResultInputMessageContent :: Maybe InputMessageContent
-  , inlineQueryResultContact  :: Maybe Contact
-  } deriving (Generic, Show)
+import qualified Data.Text as Text
 
 newtype InlineQueryResultId = InlineQueryResultId Text
   deriving (Eq, Show, Generic, ToJSON, FromJSON, Hashable)
 
-instance ToJSON InlineQueryResult where toJSON = gtoJSON
-instance FromJSON InlineQueryResult where parseJSON = gparseJSON
+data InlineQueryResultGeneric = InlineQueryResultGeneric
+  { inlineQueryResultId :: InlineQueryResultId -- ^ Unique identifier for this result, 1-64 Bytes
+  , inlineQueryResultTitle :: Maybe Text -- ^ Title of the result (only valid for "Article", "Photo", "Gif", "Mpeg4Gif", "Video", "Audio", "Voice", "Document", "Location", "Venue", "CachedPhoto", "CachedGif", "CachedMpeg4Gif", "CachedDocument", "CachedVideo", "CachedVoice" types of results)
+  , inlineQueryResultCaption :: Maybe Text -- ^ Caption of the media to be sent, 0-1024 characters after entities parsing.
+  , inlineQueryResultParseMode :: Maybe Text -- ^ Mode for parsing entities in the photo caption. See formatting options <https:\/\/core.telegram.org\/bots\/api#formatting-options> for more details.
+  , inlineQueryResultCaptionEntities :: Maybe [MessageEntity] -- ^ List of special entities that appear in the caption, which can be specified instead of @parse_mode@.
+  , inlineQueryResultReplyMarkup :: Maybe InlineKeyboardMarkup -- ^ Inline keyboard attached to the message.
+  , inlineQueryResultInputMessageContent :: Maybe InputMessageContent -- ^  Content of the message to be sent instead of the media.
+  , inlineQueryResultDescription :: Maybe Text -- ^ Short description of the result.
+  }
+  deriving (Generic, Show)
 
--- | Type of inline query result
-data InlineQueryResultType
-  = InlineQueryResultCachedAudio
-  | InlineQueryResultCachedDocument
-  | InlineQueryResultCachedGif
-  | InlineQueryResultCachedMpeg4Gif
-  | InlineQueryResultCachedPhoto
-  | InlineQueryResultCachedSticker
-  | InlineQueryResultCachedVideo
-  | InlineQueryResultCachedVoice
-  | InlineQueryResultArticle
-  | InlineQueryResultAudio
-  | InlineQueryResultContact
-  | InlineQueryResultGame
-  | InlineQueryResultDocument
-  | InlineQueryResultGif
-  | InlineQueryResultLocation
-  | InlineQueryResultMpeg4Gif
+instance ToJSON InlineQueryResultGeneric where toJSON = gtoJSON
+
+instance FromJSON InlineQueryResultGeneric where parseJSON = gparseJSON
+
+data InlineQueryResultGenericThumbnail = InlineQueryResultGenericThumbnail
+  { inlineQueryResultGenericGeneric :: InlineQueryResultGeneric
+  , inlineQueryResultGenericThumbnailUrl :: Maybe Text -- ^ URL of the thumbnail for the media.
+  , inlineQueryResultGenericThumbnailMimeType :: Maybe Text -- ^ MIME type of the thumbnail, must be one of @image/jpeg@, @image/gif@, or @video/mp4@. Defaults to @image/jpeg@.
+  , inlineQueryResultGenericThumbnailWidth :: Maybe Integer -- ^ Media width.
+  , inlineQueryResultGenericThumbnailHeight :: Maybe Integer -- ^ Media height.
+  }
+  deriving (Generic, Show)
+
+instance ToJSON InlineQueryResultGenericThumbnail where
+  toJSON InlineQueryResultGenericThumbnail{..}
+    = addJsonFields (toJSON inlineQueryResultGenericGeneric)
+      [ "thumbnail_url" .= inlineQueryResultGenericThumbnailUrl
+      , "thumbnail_mime_type" .= inlineQueryResultGenericThumbnailMimeType
+      , "thumbnail_width" .= inlineQueryResultGenericThumbnailWidth
+      , "thumbnail_height" .= inlineQueryResultGenericThumbnailHeight
+      ]
+
+instance FromJSON InlineQueryResultGenericThumbnail where
+  parseJSON = withObject "InlineQueryResult" \o -> InlineQueryResultGenericThumbnail
+    <$> parseJSON (Object o)
+    <*> o .: "thumbnail_url"
+    <*> o .: "thumbnail_mime_type"
+    <*> o .: "thumbnail_width"
+    <*> o .: "thumbnail_height"
+
+-- | This object represents one result of an inline query
+data InlineQueryResult
+  = InlineQueryResultArticle
+    { inlineQueryResultArticleGeneric :: InlineQueryResultGenericThumbnail
+    , inlineQueryResultArticleUrl :: Maybe Text -- ^ URL of the result.
+    , inlineQueryResultArticleHideUrl :: Maybe Bool -- ^ 'True' if you don't want the URL to be shown in the message.
+    }
   | InlineQueryResultPhoto
-  | InlineQueryResultVenue
+    { inlineQueryResultPhotoGeneric :: InlineQueryResultGenericThumbnail
+    , inlineQueryResultPhotoPhotoUrl :: Text -- ^ A valid URL of the photo. Photo must be in **JPEG** format. Photo size must not exceed 5MB.
+    , inlineQueryResultPhotoPhotoWidth :: Maybe Integer -- ^ Width of the photo.
+    , inlineQueryResultPhotoPhotoHeight :: Maybe Integer -- ^ Height of the photo.
+    }
+  | InlineQueryResultGif
+    { inlineQueryResultGifGeneric :: InlineQueryResultGenericThumbnail
+    , inlineQueryResultGifGifUrl :: Text -- ^ A valid URL for the GIF file. File size must not exceed 1MB.
+    , inlineQueryResultGifGifWidth :: Maybe Integer -- ^ Width of the GIF.
+    , inlineQueryResultGifGifHeight :: Maybe Integer -- ^ Height of the GIF.
+    , inlineQueryResultGifGifDuration :: Maybe Integer -- ^ Duration of the GIF in seconds.
+    }
+  | InlineQueryResultMpeg4Gif
+    { inlineQueryResultMpeg4GifGeneric :: InlineQueryResultGenericThumbnail
+    , inlineQueryResultMpeg4GifMpeg4Url :: Text -- ^ A valid URL for the MPEG4 file. File size must not exceed 1MB.
+    , inlineQueryResultMpeg4GifMpeg4Width :: Maybe Integer -- ^ Video width.
+    , inlineQueryResultMpeg4GifMpeg4Height :: Maybe Integer -- ^ Video height.
+    , inlineQueryResultMpeg4GifMpeg4Duration :: Maybe Integer -- ^ Video duration in seconds.
+    }
   | InlineQueryResultVideo
+    { inlineQueryResultVideoGeneric :: InlineQueryResultGenericThumbnail
+    , inlineQueryResultVideoVideoUrl :: Text -- ^ A valid URL for the embedded video player or video file.
+    , inlineQueryResultVideoMimeType :: Text -- ^ MIME type of the content of the video URL, @text/html@ or @video/mp4@.
+    , inlineQueryResultVideoVideoWidth :: Maybe Integer -- ^ Video width.
+    , inlineQueryResultVideoVideoHeight :: Maybe Integer -- ^ Video height.
+    , inlineQueryResultVideoVideoDuration :: Maybe Integer -- ^ Video duration in seconds.
+    }
+  | InlineQueryResultAudio
+    { inlineQueryResultAudioGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultAudioAudioUrl :: Text -- ^ A valid URL for the audio file.
+    , inlineQueryResultAudioPerformer :: Maybe Text -- ^ Performer.
+    , inlineQueryResultAudioAudioDuration :: Maybe Integer -- ^ Audio duration in seconds.
+    }
   | InlineQueryResultVoice
-  deriving (Eq, Show, Generic)
+    { inlineQueryResultVoiceGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultVoiceVoiceUrl :: Text -- ^ A valid URL for the voice recording.
+    , inlineQueryResultVoiceVoiceDuration :: Maybe Integer -- ^ Recording duration in seconds.
+    }
+  | InlineQueryResultDocument
+    { inlineQueryResultDocumentGeneric :: InlineQueryResultGenericThumbnail
+    , inlineQueryResultDocumentDocumentUrl :: Text -- ^ A valid URL for the file.
+    , inlineQueryResultDocumentMimeType :: Text -- ^ MIME type of the content of the file, either @application/pdf@ or @application/zip@.
+    }
+  | InlineQueryResultLocation
+    { inlineQueryResultLocationGeneric :: InlineQueryResultGenericThumbnail
+    , inlineQueryResultLocationLatitude :: Float -- ^ Location latitude in degrees.
+    , inlineQueryResultLocationLongitude :: Float -- ^ Location longitude in degrees.
+    , inlineQueryResultLocationHorizontalAccuracy :: Maybe Float -- ^ The radius of uncertainty for the location, measured in meters; 0-1500.
+    , inlineQueryResultLocationLivePeriod :: Maybe Seconds -- ^ Period in seconds for which the location can be updated, should be between 60 and 86400.
+    , inlineQueryResultLocationHeading :: Maybe Int -- ^ For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+    , inlineQueryResultLocationProximityAlertRadius :: Maybe Int -- ^ For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+    }
+  | InlineQueryResultVenue
+    { inlineQueryResultVenueGeneric :: InlineQueryResultGenericThumbnail
+    , inlineQueryResultVenueLatitude :: Float -- ^ Latitude of the venue location in degrees.
+    , inlineQueryResultVenueLongitude :: Float -- ^ Longitude of the venue location in degrees.
+    , inlineQueryResultVenueAddress :: Text -- ^ Address of the venue.
+    , inlineQueryResultVenueFoursquareId :: Maybe Text -- ^ Foursquare identifier of the venue if known.
+    , inlineQueryResultVenueFoursquareType :: Maybe Text -- ^ Foursquare type of the venue, if known. (For example, @arts_entertainment/default@, @arts_entertainment/aquarium@ or @food/icecream@.)
+    , inlineQueryResultVenueGooglePlaceId :: Maybe Text -- ^ Google Places identifier of the venue.
+    , inlineQueryResultVenueGooglePlaceType :: Maybe Text -- ^ Google Places type of the venue. (See supported types <https:\/\/developers.google.com\/places\/web-service\/supported_types>.)
+    }
+  | InlineQueryResultContact
+    { inlineQueryResultContactGeneric :: InlineQueryResultGenericThumbnail
+    , inlineQueryResultContactPhoneNumber :: Text -- ^ Contact's phone number.
+    , inlineQueryResultContactFirstName :: Text -- ^ Contact's first name.
+    , inlineQueryResultContactLastName :: Maybe Text -- ^ Contact's last name.
+    , inlineQueryResultContactVcard :: Maybe Text -- ^ Additional data about the contact in the form of a vCard <https:\/\/en.wikipedia.org\/wiki\/VCard>, 0-2048 bytes.
+    }
+  | InlineQueryResultGame
+    { inlineQueryResultGameGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultGameGameShortName :: Text -- ^ Short name of the game.
+    }
+  | InlineQueryResultCachedPhoto
+    { inlineQueryResultCachedPhotoGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultCachedPhotoPhotoFileId :: FileId -- ^ A valid file identifier of the photo.
+    }
+  | InlineQueryResultCachedGif
+    { inlineQueryResultCachedGifGeneric :: InlineQueryResultGeneric
+    , iinlineQueryResultCachedGifGifFileId :: FileId -- ^ A valid file identifier for the GIF file.
+    }
+  | InlineQueryResultCachedMpeg4Gif
+    { inlineQueryResultCachedMpeg4GifGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultCachedMpeg4GifMpeg4FileId :: FileId -- ^ A valid file identifier for the MPEG4 file.
+    }
+  | InlineQueryResultCachedSticker
+    { inlineQueryResultCachedStickerGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultCachedStickerStickerFileId :: FileId -- ^ A valid file identifier of the sticker.
+    }
+  | InlineQueryResultCachedDocument
+    { inlineQueryResultCachedDocumentGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultCachedDocumentDocumentFileId :: FileId -- ^ A valid file identifier for the file.
+    }
+  | InlineQueryResultCachedVideo
+    { inlineQueryResultCachedVideoGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultCachedVideoVideoFileId :: FileId -- ^ A valid file identifier for the video file.
+    }
+  | InlineQueryResultCachedVoice
+    { inlineQueryResultCachedVoiceGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultCachedVoiceVoiceFileId :: FileId -- ^ A valid file identifier for the voice message.
+    }
+  | InlineQueryResultCachedAudio
+    { inlineQueryResultCachedAudioGeneric :: InlineQueryResultGeneric
+    , inlineQueryResultCachedAudioAudioFileId :: FileId -- ^ A valid file identifier for the audio file.
+    }
+  deriving (Generic, Show)
 
-getType :: InlineQueryResultType -> Text
-getType InlineQueryResultCachedAudio = "audio"
-getType InlineQueryResultCachedDocument = "document"
-getType InlineQueryResultCachedGif = "gif"
-getType InlineQueryResultCachedMpeg4Gif = "mpeg4_gif"
-getType InlineQueryResultCachedPhoto = "photo"
-getType InlineQueryResultCachedSticker = "sticker"
-getType InlineQueryResultCachedVideo = "video"
-getType InlineQueryResultCachedVoice = "voice"
-getType InlineQueryResultArticle = "article"
-getType InlineQueryResultAudio = "audio"
-getType InlineQueryResultContact = "contact"
-getType InlineQueryResultGame = "game"
-getType InlineQueryResultDocument = "document"
-getType InlineQueryResultGif = "gif"
-getType InlineQueryResultLocation = "location"
-getType InlineQueryResultMpeg4Gif = "mpeg4_gif"
-getType InlineQueryResultPhoto = "photo"
-getType InlineQueryResultVenue = "venue"
-getType InlineQueryResultVideo = "video"
-getType InlineQueryResultVoice = "voice"
+{-
+    InputMediaVideo imgt width height duration streaming spoiler ->
+      addJsonFields (toJSON imgt)
+                (addType "video"
+                [ "width" .= width
+                , "height" .= height
+                , "duration" .= duration
+                , "support_streaming" .= streaming
+                , "has_spoiler" .= spoiler
+                ])
+    InputMediaAnimation imgt width height duration spoiler ->
+      addJsonFields (toJSON imgt)
+                (addType "animation"
+                [ "width" .= width
+                , "height" .= height
+                , "duration" .= duration
+                , "has_spoiler" .= spoiler
+                ])
+-}
 
-instance ToJSON InlineQueryResultType where
-  toJSON = String . getType
+instance ToJSON InlineQueryResult where
+  toJSON = \case
+    InlineQueryResultArticle g url hideUrl ->
+      addJsonFields (toJSON g)
+        (addType "article"
+        [ "url" .= url
+        , "hide_url" .= hideUrl
+        ])
+    InlineQueryResultPhoto g photoUrl photoWidth photoHeight ->
+      addJsonFields (toJSON g)
+        (addType "photo"
+        [ "photo_url" .= photoUrl
+        , "photo_width" .= photoWidth
+        , "photo_height" .= photoHeight
+        ])
+    InlineQueryResultGif g gifUrl gifWidth gifHeight gifDuration ->
+      addJsonFields (toJSON g)
+        (addType "gif"
+        [ "gif_url" .= gifUrl
+        , "gif_width" .= gifWidth
+        , "gif_height" .= gifHeight
+        , "gif_duration" .= gifDuration
+        ])
+    InlineQueryResultMpeg4Gif g mpeg4Url mpeg4Width mpeg4Height mpeg4Duration ->
+      addJsonFields (toJSON g)
+        (addType "mpeg4_gif"
+        [ "mpeg4_url" .= mpeg4Url
+        , "mpeg4_width" .= mpeg4Width
+        , "mpeg4_height" .= mpeg4Height
+        , "mpeg4_duration" .= mpeg4Duration
+        ])
+    InlineQueryResultVideo g videoUrl mimeType videoWidth videoHeight videoDuration ->
+      addJsonFields (toJSON g)
+        (addType "video"
+        [ "video_url" .= videoUrl
+        , "mime_type" .= mimeType
+        , "video_width" .= videoWidth
+        , "video_height" .= videoHeight
+        , "video_duration" .= videoDuration
+        ])
+    InlineQueryResultAudio g audioUrl performer audioDuration ->
+      addJsonFields (toJSON g)
+        (addType "audio"
+        [ "audio_url" .= audioUrl
+        , "performer" .= performer
+        , "audio_duration" .= audioDuration
+        ])
+    InlineQueryResultVoice g voiceUrl voiceDuration ->
+      addJsonFields (toJSON g)
+        (addType "voice"
+        [ "voice_url" .= voiceUrl
+        , "voice_duration" .= voiceDuration
+        ])
+    InlineQueryResultDocument g documentUrl mimeType ->
+      addJsonFields (toJSON g)
+        (addType "document"
+        [ "document_url" .= documentUrl
+        , "mime_type" .= mimeType
+        ])
+    InlineQueryResultLocation g latitude longitude horizontalAccuracy livePeriod heading proximityAlertRadius ->
+      addJsonFields (toJSON g)
+        (addType "location"
+        [ "latitude" .= latitude
+        , "longitude" .= longitude
+        , "horizontal_accuracy" .= horizontalAccuracy
+        , "live_period" .= livePeriod
+        , "heading" .= heading
+        , "proximity_alert_radius" .= proximityAlertRadius
+        ])
+    InlineQueryResultVenue g latitude longitude address foursquareId foursquareType googlePlaceId googlePlaceType ->
+      addJsonFields (toJSON g)
+        (addType "venue"
+        [ "latitude" .= latitude
+        , "longitude" .= longitude
+        , "address" .= address
+        , "foursquare_id" .= foursquareId
+        , "foursquare_type" .= foursquareType
+        , "google_place_id" .= googlePlaceId
+        , "google_place_type" .= googlePlaceType
+        ])
+    InlineQueryResultContact g phoneNumber firstName lastName vcard ->
+      addJsonFields (toJSON g)
+        (addType "contact"
+        [ "phone_number" .= phoneNumber
+        , "first_name" .= firstName
+        , "last_name" .= lastName
+        , "vcard" .= vcard
+        ])
+    InlineQueryResultGame g gameShortName ->
+      addJsonFields (toJSON g)
+        (addType "game"
+        [ "game_short_name" .= gameShortName
+        ])
+    InlineQueryResultCachedPhoto g photoFileId ->
+      addJsonFields (toJSON g)
+        (addType "photo"
+        [ "photo_file_id" .= photoFileId
+        ])
+    InlineQueryResultCachedGif g gifFileId ->
+      addJsonFields (toJSON g)
+        (addType "gif"
+        [ "gif_file_id" .= gifFileId
+        ])
+    InlineQueryResultCachedMpeg4Gif g mpeg4FileId ->
+      addJsonFields (toJSON g)
+        (addType "mpeg4_gif"
+        [ "mpeg4_file_id" .= mpeg4FileId
+        ])
+    InlineQueryResultCachedSticker g stickerFileId ->
+      addJsonFields (toJSON g)
+        (addType "sticker"
+        [ "sticker_file_id" .= stickerFileId
+        ])
+    InlineQueryResultCachedDocument g documentFileId ->
+      addJsonFields (toJSON g)
+        (addType "document"
+        [ "document_file_id" .= documentFileId
+        ])
+    InlineQueryResultCachedVideo g videoFileId ->
+      addJsonFields (toJSON g)
+        (addType "video"
+        [ "video_file_id" .= videoFileId
+        ])
+    InlineQueryResultCachedVoice g voiceFileId ->
+      addJsonFields (toJSON g)
+        (addType "voice"
+        [ "voice_file_id" .= voiceFileId
+        ])
+    InlineQueryResultCachedAudio g audioFileId ->
+      addJsonFields (toJSON g)
+        (addType "audio"
+        [ "audio_file_id" .= audioFileId
+        ])
 
-instance FromJSON InlineQueryResultType where parseJSON = gparseJSON
-
-makeDefault ''InlineQueryResult
+instance FromJSON InlineQueryResult where
+  parseJSON = withObject "InlineQueryResult" \o ->
+    (o .: "type" :: Parser Text) >>= \case
+    "article" -> InlineQueryResultArticle
+      <$> parseJSON (Object o)
+      <*> o .: "url"
+      <*> o .: "hide_url"
+    "photo" -> parseFileId o "photo_file_id" >>= \case
+      Nothing -> InlineQueryResultPhoto
+        <$> parseJSON (Object o) -- generic thumbnail
+        <*> o .: "photo_url"
+        <*> o .: "photo_width"
+        <*> o .: "photo_height"
+      Just fileId -> InlineQueryResultCachedPhoto <$> parseJSON (Object o) <*> pure fileId
+    "gif" -> parseFileId o "gif_file_id" >>= \case
+      Nothing -> InlineQueryResultGif
+        <$> parseJSON (Object o) -- generic thumbnail
+        <*> o .: "gif_url"
+        <*> o .: "gif_width"
+        <*> o .: "gif_height"
+        <*> o .: "gif_duration"
+      Just fileId -> InlineQueryResultCachedGif <$> parseJSON (Object o) <*> pure fileId
+    "mpeg4_gif" -> parseFileId o "mpeg4_file_id" >>= \case
+      Nothing -> InlineQueryResultMpeg4Gif
+        <$> parseJSON (Object o) -- generic thumbnail
+        <*> o .: "mpeg4_url"
+        <*> o .: "mpeg4_width"
+        <*> o .: "mpeg4_height"
+        <*> o .: "mpeg4_duration"
+      Just fileId -> InlineQueryResultCachedMpeg4Gif
+        <$> parseJSON (Object o)
+        <*> pure fileId
+    "video" -> parseFileId o "video_file_id" >>= \case
+      Nothing -> InlineQueryResultVideo
+        <$> parseJSON (Object o)
+        <*> o .: "video_url"
+        <*> o .: "mime_type"
+        <*> o .: "video_width"
+        <*> o .: "video_height"
+        <*> o .: "video_duration"
+      Just fileId -> InlineQueryResultCachedVideo
+        <$> parseJSON (Object o)
+        <*> pure fileId
+    "audio" -> parseFileId o "audio_file_id" >>= \case
+      Nothing -> InlineQueryResultAudio
+        <$> parseJSON (Object o)
+        <*> o .: "audio_url"
+        <*> o .: "performer"
+        <*> o .: "duration"
+      Just fileId -> InlineQueryResultCachedAudio <$> parseJSON (Object o) <*> pure fileId
+    "voice" -> parseFileId o "voice_file_id" >>= \case
+      Nothing -> InlineQueryResultVoice
+        <$> parseJSON (Object o)
+        <*> o .: "voice_url"
+        <*> o .: "voice_duration"
+      Just fileId -> InlineQueryResultCachedVoice <$> parseJSON (Object o) <*> pure fileId
+    "document" -> parseFileId o "document_file_id" >>= \case
+      Nothing -> InlineQueryResultDocument
+        <$> parseJSON (Object o)
+        <*> o .: "document_url"
+        <*> o .: "mime_type"
+      Just fileId -> InlineQueryResultCachedDocument <$> parseJSON (Object o) <*> pure fileId
+    "location" -> InlineQueryResultLocation
+      <$> parseJSON (Object o)
+      <*> o .: "latitude"
+      <*> o .: "longitude"
+      <*> o .: "horizontal_accuracy"
+      <*> o .: "live_period"
+      <*> o .: "heading"
+      <*> o .: "proximity_alert_radius"
+    "venue" -> InlineQueryResultVenue
+      <$> parseJSON (Object o)
+      <*> o .: "latitude"
+      <*> o .: "longitude"
+      <*> o .: "address"
+      <*> o .: "foursquare_id"
+      <*> o .: "foursquare_type"
+      <*> o .: "google_place_id"
+      <*> o .: "google_place_type"
+    "contact" -> InlineQueryResultContact
+      <$> parseJSON (Object o)
+      <*> o .: "phone_number"
+      <*> o .: "first_name"
+      <*> o .: "last_name"
+      <*> o .: "vcard"
+    "game" -> InlineQueryResultGame
+      <$> parseJSON (Object o)
+      <*> o .: "game_short_name"
+    t -> fail $ Text.unpack ("Unknown type: " <> t)
+    where
+      parseFileId o fileField = o .:? fileField :: Parser (Maybe FileId)
+    
+foldMap makeDefault
+  [ ''InlineQueryResultGeneric
+  , ''InlineQueryResultGenericThumbnail
+  ]

--- a/telegram-bot-api/src/Telegram/Bot/API/InlineMode/InlineQueryResult.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/InlineMode/InlineQueryResult.hs
@@ -182,26 +182,6 @@ data InlineQueryResult
     }
   deriving (Generic, Show)
 
-{-
-    InputMediaVideo imgt width height duration streaming spoiler ->
-      addJsonFields (toJSON imgt)
-                (addType "video"
-                [ "width" .= width
-                , "height" .= height
-                , "duration" .= duration
-                , "support_streaming" .= streaming
-                , "has_spoiler" .= spoiler
-                ])
-    InputMediaAnimation imgt width height duration spoiler ->
-      addJsonFields (toJSON imgt)
-                (addType "animation"
-                [ "width" .= width
-                , "height" .= height
-                , "duration" .= duration
-                , "has_spoiler" .= spoiler
-                ])
--}
-
 instance ToJSON InlineQueryResult where
   toJSON = \case
     InlineQueryResultArticle g url hideUrl ->
@@ -428,6 +408,43 @@ instance FromJSON InlineQueryResult where
     where
       parseFileId o fileField = o .:? fileField :: Parser (Maybe FileId)
     
+defInlineQueryResultArticle :: InlineQueryResultGenericThumbnail -> InlineQueryResult
+defInlineQueryResultArticle g = InlineQueryResultArticle g Nothing Nothing
+
+defInlineQueryResultPhotoUrl :: InlineQueryResultGenericThumbnail -> Text -> InlineQueryResult
+defInlineQueryResultPhotoUrl g photoUrl = InlineQueryResultPhoto g photoUrl Nothing Nothing
+
+defInlineQueryResultGif :: InlineQueryResultGenericThumbnail -> Text -> InlineQueryResult
+defInlineQueryResultGif g gifUrl = InlineQueryResultGif g gifUrl Nothing Nothing Nothing
+
+defInlineQueryResultMpeg4Gif :: InlineQueryResultGenericThumbnail -> Text -> InlineQueryResult
+defInlineQueryResultMpeg4Gif g mpeg4Url = InlineQueryResultMpeg4Gif g mpeg4Url Nothing Nothing Nothing
+
+defInlineQueryResultVideo :: InlineQueryResultGenericThumbnail -> Text -> Text -> InlineQueryResult
+defInlineQueryResultVideo g videoUrl mimeType
+  = InlineQueryResultVideo g videoUrl mimeType Nothing Nothing Nothing
+
+defInlineQueryResultAudio :: InlineQueryResultGeneric -> Text -> InlineQueryResult
+defInlineQueryResultAudio g audioUrl = InlineQueryResultAudio g audioUrl Nothing Nothing
+
+defInlineQueryResultVoice :: InlineQueryResultGeneric -> Text -> InlineQueryResult
+defInlineQueryResultVoice g voiceUrl = InlineQueryResultVoice g voiceUrl Nothing
+
+defInlineQueryResultDocument :: InlineQueryResultGenericThumbnail -> Text -> Text -> InlineQueryResult
+defInlineQueryResultDocument = InlineQueryResultDocument
+
+defInlineQueryResultLocation :: InlineQueryResultGenericThumbnail -> Float -> Float -> InlineQueryResult
+defInlineQueryResultLocation g lat lon
+  = InlineQueryResultLocation g lat lon Nothing Nothing Nothing Nothing
+
+defInlineQueryResultVenue :: InlineQueryResultGenericThumbnail -> Float -> Float -> Text -> InlineQueryResult
+defInlineQueryResultVenue g lat lon address
+  = InlineQueryResultVenue g lat lon address Nothing Nothing Nothing Nothing
+
+defInlineQueryResultContact :: InlineQueryResultGenericThumbnail -> Text -> Text -> InlineQueryResult
+defInlineQueryResultContact g phoneNumber firstName
+  = InlineQueryResultContact g phoneNumber firstName Nothing Nothing
+
 foldMap makeDefault
   [ ''InlineQueryResultGeneric
   , ''InlineQueryResultGenericThumbnail

--- a/telegram-bot-api/src/Telegram/Bot/API/InlineMode/InputMessageContent.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/InlineMode/InputMessageContent.hs
@@ -6,38 +6,62 @@ import           Data.Text                       (Text)
 import           GHC.Generics                    (Generic)
 
 import           Telegram.Bot.API.Internal.Utils
+import           Telegram.Bot.API.Types.LabeledPrice
 
 -- | Represents the content of a text message to be sent as the result of an inline query.
-data InputMessageContent =
-  InputTextMessageContent -- ^ Represents the [content](https://core.telegram.org/bots/api#inputmessagecontent) of a text message to be sent as the result of an inline query.
-  { inputMessageContentMessageText :: Text -- ^ Text of the message to be sent, 1-4096 characters
-  , inputMessageContentParseMode :: Maybe Text -- ^ Mode for parsing entities in the message text. See [formatting options](https://core.telegram.org/bots/api#formatting-options) for more details.
-  , inputMessageContentDisableWebPagePrefiew :: Maybe Bool -- ^ Disables link previews for links in the sent message
-  }
+data InputMessageContent
+  = InputTextMessageContent -- ^ Represents the [content](https://core.telegram.org/bots/api#inputmessagecontent) of a text message to be sent as the result of an inline query.
+    { inputMessageContentMessageText :: Text -- ^ Text of the message to be sent, 1-4096 characters
+    , inputMessageContentParseMode :: Maybe Text -- ^ Mode for parsing entities in the message text. See [formatting options](https://core.telegram.org/bots/api#formatting-options) for more details.
+    , inputMessageContentDisableWebPagePrefiew :: Maybe Bool -- ^ Disables link previews for links in the sent message
+    }
   | InputLocationMessageContent                                      -- ^ Represents the [content](https://core.telegram.org/bots/api#inputmessagecontent) of a location message to be sent as the result of an inline query.
-  { inputMessageContentLatitude :: Float                     -- ^ Latitude of the location in degrees
-  , inputMessageContentLongitude :: Float                    -- ^ Longitude of the location in degrees
-  , inputMessageContentHorizontalAccuracy :: Maybe Float     -- ^ The radius of uncertainty for the location, measured in meters; 0-1500
-  , inputMessageContentLivePeriod :: Maybe Integer           -- ^ Period in seconds for which the location can be updated, should be between 60 and 86400.
-  , inputMessageContentHeading :: Maybe Integer              -- ^ For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
-  , inputMessageContentProximityAlertRadius :: Maybe Integer -- ^ For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
-  }
+    { inputMessageContentLatitude :: Float                     -- ^ Latitude of the location in degrees
+    , inputMessageContentLongitude :: Float                    -- ^ Longitude of the location in degrees
+    , inputMessageContentHorizontalAccuracy :: Maybe Float     -- ^ The radius of uncertainty for the location, measured in meters; 0-1500
+    , inputMessageContentLivePeriod :: Maybe Integer           -- ^ Period in seconds for which the location can be updated, should be between 60 and 86400.
+    , inputMessageContentHeading :: Maybe Integer              -- ^ For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+    , inputMessageContentProximityAlertRadius :: Maybe Integer -- ^ For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+    }
   | InputVenueMessageContent                              -- ^ Represents the content of a [venue](https://core.telegram.org/bots/api#inputmessagecontent) message to be sent as the result of an inline query.
-  { inputMessageContentLatitude :: Float             -- ^ Latitude of the venue in degrees
-  , inputMessageContentLongitude :: Float            -- ^ Longitude of the venue in degrees
-  , inputMessageContentTitle :: Text                 -- ^ Name of the venue
-  , inputMessageContentAddress :: Text               -- ^ Address of the venue
-  , inputMessageContentFoursquareId :: Maybe Text    -- ^ Foursquare identifier of the venue, if known
-  , inputMessageContentFoursquareType :: Maybe Text  -- ^ Foursquare type of the venue, if known. (For example, “arts_entertainment\/default”, “arts_entertainment\/aquarium” or “food\/icecream”.)
-  , inputMessageContentGooglePlaceId :: Maybe Text   -- ^ Google Places identifier of the venue
-  , inputMessageContentGooglePlaceType :: Maybe Text -- ^ Google Places type of the venue. (See [supported types](https://developers.google.com/places/web-service/supported_types).)
-  }
+    { inputMessageContentLatitude :: Float             -- ^ Latitude of the venue in degrees
+    , inputMessageContentLongitude :: Float            -- ^ Longitude of the venue in degrees
+    , inputMessageContentTitle :: Text                 -- ^ Name of the venue
+    , inputMessageContentAddress :: Text               -- ^ Address of the venue
+    , inputMessageContentFoursquareId :: Maybe Text    -- ^ Foursquare identifier of the venue, if known
+    , inputMessageContentFoursquareType :: Maybe Text  -- ^ Foursquare type of the venue, if known. (For example, “arts_entertainment\/default”, “arts_entertainment\/aquarium” or “food\/icecream”.)
+    , inputMessageContentGooglePlaceId :: Maybe Text   -- ^ Google Places identifier of the venue
+    , inputMessageContentGooglePlaceType :: Maybe Text -- ^ Google Places type of the venue. (See [supported types](https://developers.google.com/places/web-service/supported_types).)
+    }
   | InputContactMessageContent                         -- ^ Represents the [content](https://core.telegram.org/bots/api#inputmessagecontent) of a contact message to be sent as the result of an inline query.
-  { inputMessageContentPhoneNumber :: Text      -- ^ Contact's phone number
-  , inputMessageContentFirstName :: Text        -- ^ Contact's first name
-  , inputMessageContentSecondName :: Maybe Text -- ^ Contact's last name
-  , inputMessageContentVcard :: Maybe Text      -- ^ Additional data about the contact in the form of a [vCard](https://en.wikipedia.org/wiki/VCard), 0-2048 bytes
-  } deriving (Generic, Show)
+    { inputMessageContentPhoneNumber :: Text      -- ^ Contact's phone number
+    , inputMessageContentFirstName :: Text        -- ^ Contact's first name
+    , inputMessageContentSecondName :: Maybe Text -- ^ Contact's last name
+    , inputMessageContentVcard :: Maybe Text      -- ^ Additional data about the contact in the form of a [vCard](https://en.wikipedia.org/wiki/VCard), 0-2048 bytes
+    }
+  | InputInvoiceMessageContent                        -- ^ Represents the [content](https://core.telegram.org/bots/api#inputmessagecontent) of an invoice message to be sent as the result of an inline query.
+    { inputMessageContentTitle :: Text -- ^ Product name, 1-32 characters.
+    , inputMessageContentDescription :: Text -- ^ Product description, 1-255 characters.
+    , inputMessageContentPayload :: Text -- ^ Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
+    , inputMessageContentProviderToken :: Text -- ^ Payment provider token, obtained via [@BotFather](https://t.me/botfather).
+    , inputMessageContentCurrency :: Text -- ^ Three-letter ISO 4217 currency code, see [more on currencies](https://core.telegram.org/bots/payments#supported-currencies).
+    , inputMessageContentPrices :: [LabeledPrice] -- ^ Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.).
+    , inputMessageContentMaxTipAmount :: Maybe Integer -- ^ The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of @US$ 1.45@ pass @max_tip_amount = 145@. See the exp parameter in [currencies.json](https://core.telegram.org/bots/payments/currencies.json), it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0.
+    , inputMessageContentSuggestedTipAmounts :: Maybe [Integer] -- ^ A JSON-serialized array of suggested amounts of tip in the smallest units of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed @max_tip_amount@.
+    , inputMessageContentProviderData :: Maybe Text -- ^ A JSON-serialized object for data about the invoice, which will be shared with the payment provider. A detailed description of the required fields should be provided by the payment provider.
+    , inputMessageContentPhotoUrl :: Maybe Text -- ^ URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service.
+    , inputMessageContentPhotoSize :: Maybe Integer -- ^ Photo size in bytes.
+    , inputMessageContentPhotoWidth :: Maybe Integer -- ^ Photo width.
+    , inputMessageContentPhotoHeight :: Maybe Integer -- ^ Photo height.
+    , inputMessageContentNeedName :: Maybe Bool -- ^ 'True' if you require the user's full name to complete the order.
+    , inputMessageContentNeedPhoneNumber :: Maybe Bool -- ^ 'True' if you require the user's phone number to complete the order.
+    , inputMessageContentNeedEmail :: Maybe Bool -- ^ 'True' if you require the user's email address to complete the order.
+    , inputMessageContentNeedShippingAddress :: Maybe Bool -- ^ 'True' if you require the user's shipping address to complete the order.
+    , inputMessageContentSendPhoneNumberToProvider :: Maybe Bool -- ^ 'True' if the user's phone number should be sent to provider.
+    , inputMessageContentSendEmailToProvider :: Maybe Bool -- ^ 'True' if the user's email address should be sent to provider.
+    , inputMessageContentIsFlexible :: Maybe Bool -- ^ 'True' if the final price depends on the shipping method.
+    }
+  deriving (Generic, Show)
 
 -- ** Helper functions to easily construct 'InputMessageContent'
 

--- a/telegram-bot-api/src/Telegram/Bot/API/Types/InputMedia.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Types/InputMedia.hs
@@ -28,7 +28,7 @@ data InputMediaGeneric = InputMediaGeneric
   { inputMediaGenericMedia :: InputFile -- ^ File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
   , inputMediaGenericCaption :: Maybe Text -- ^ Caption of the photo to be sent, 0-1024 characters after entities parsing.
   , inputMediaGenericParseMode :: Maybe Text -- ^ Mode for parsing entities in the photo caption. See formatting options <https:\/\/core.telegram.org\/bots\/api#formatting-options> for more details.
-  , inputMediaGenericCaptionEntities :: Maybe [MessageEntity] -- ^ List of special entities that appear in the caption, which can be specified instead of parse_mode.
+  , inputMediaGenericCaptionEntities :: Maybe [MessageEntity] -- ^ List of special entities that appear in the caption, which can be specified instead of @parse_mode@.
   }
   deriving Generic
 
@@ -45,20 +45,21 @@ instance ToMultipart Tmp InputMediaGeneric where
         \t -> Input "caption_entities" (TL.toStrict $ encodeToLazyText t)
       ]
 
-data InputMediaGenericThumb = InputMediaGenericThumb
+data InputMediaGenericThumbnail = InputMediaGenericThumbnail
   { inputMediaGenericGeneric :: InputMediaGeneric
   , inputMediaGenericThumbnail :: Maybe InputFile -- ^ Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. 
   }
 
-instance ToJSON InputMediaGenericThumb where
-  toJSON InputMediaGenericThumb{..}
+instance ToJSON InputMediaGenericThumbnail where
+  toJSON InputMediaGenericThumbnail{..}
     = addJsonFields (toJSON inputMediaGenericGeneric)
       ["thumbnail" .= inputMediaGenericThumbnail]
 
-instance ToMultipart Tmp InputMediaGenericThumb where
+instance ToMultipart Tmp InputMediaGenericThumbnail where
   toMultipart = \case
-    InputMediaGenericThumb generic Nothing -> toMultipart generic
-    InputMediaGenericThumb generic (Just thumb) -> makeFile "thumbnail" thumb (toMultipart generic)
+    InputMediaGenericThumbnail generic Nothing -> toMultipart generic
+    InputMediaGenericThumbnail generic (Just thumbnail) ->
+      makeFile "thumbnail" thumbnail (toMultipart generic)
 
 
 data InputMedia
@@ -67,7 +68,7 @@ data InputMedia
     , inputMediaPhotoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
     }
   | InputMediaVideo -- ^ Represents a video to be sent.
-    { inputMediaVideoGeneric :: InputMediaGenericThumb
+    { inputMediaVideoGeneric :: InputMediaGenericThumbnail
     , inputMediaVideoWidth :: Maybe Integer -- ^ Video width
     , inputMediaVideoHeight :: Maybe Integer -- ^ Video height
     , inputMediaVideoDuration :: Maybe Integer -- ^ Video duration in seconds
@@ -75,20 +76,20 @@ data InputMedia
     , inputMediaVideoHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
     }
   | InputMediaAnimation -- ^ Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.
-    { inputMediaAnimationGeneric :: InputMediaGenericThumb
+    { inputMediaAnimationGeneric :: InputMediaGenericThumbnail
     , inputMediaAnimationWidth :: Maybe Integer -- ^ Animation width
     , inputMediaAnimationHeight :: Maybe Integer -- ^ Animation height
     , inputMediaAnimationDuration :: Maybe Integer -- ^ Animation duration in seconds
     , inputMediaAnimationHasSpoiler :: Maybe Bool -- ^ Pass 'True' if the video needs to be covered with a spoiler animation.
     }
   | InputMediaAudio -- ^ Represents an audio file to be treated as music to be sent.
-    { inputMediaAudioGeneric :: InputMediaGenericThumb
+    { inputMediaAudioGeneric :: InputMediaGenericThumbnail
     , inputMediaAudioDuration :: Maybe Integer -- ^ Duration of the audio in seconds
     , inputMediaAudioPerformer :: Maybe Text -- ^ Performer of the audio
     , inputMediaAudioTitle :: Maybe Text -- ^ Title of the audio
     }
   | InputMediaDocument -- ^ Represents a general file to be sent.
-    { inputMediaDocumentGeneric :: InputMediaGenericThumb
+    { inputMediaDocumentGeneric :: InputMediaGenericThumbnail
     , inputMediaDocumentDisableContentTypeDetection :: Maybe Bool -- ^ Disables automatic server-side content type detection for files uploaded using multipart/form-data. Always True, if the document is sent as part of an album.
     }
 
@@ -189,6 +190,7 @@ data InputFile
   = InputFileId FileId
   | FileUrl Text
   | InputFile FilePath ContentType
+  deriving (Generic, Show)
 
 instance ToJSON InputFile where
   toJSON (InputFileId i) = toJSON i

--- a/telegram-bot-api/src/Telegram/Bot/API/Types/Sticker.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Types/Sticker.hs
@@ -8,9 +8,22 @@ import GHC.Generics (Generic)
 
 import Telegram.Bot.API.Types.Common 
 import Telegram.Bot.API.Types.File
+import Telegram.Bot.API.Types.InputMedia
 import Telegram.Bot.API.Types.MaskPosition
 import Telegram.Bot.API.Types.PhotoSize
 import Telegram.Bot.API.Internal.Utils
+
+-- ** 'InputSticker'
+
+data InputSticker = InputSticker
+  { inputStickerSticker :: InputFile -- ^ The added sticker. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, upload a new one using @multipart/form-data@, or pass @attach://<file_attach_name>@ to upload a new one using @multipart/form-data@ under @<file_attach_name>@ name. Animated and video stickers can't be uploaded via HTTP URL.
+  , inputStickerEmojiList :: [Text] -- ^ List of 1-20 emoji associated with the sticker.
+  , inputStickerMaskPosition :: Maybe MaskPosition -- ^ Position where the mask should be placed on faces. For “mask” stickers only.
+  , inputStickerKeywords :: Maybe [Text] -- ^ List of 0-20 search keywords for the sticker with total length of up to 64 characters. For “regular” and “custom_emoji” stickers only.
+  }
+  deriving (Generic, Show)
+
+instance ToJSON   InputSticker where toJSON = gtoJSON
 
 -- ** 'Sticker'
 

--- a/telegram-bot-simple/examples/EchoBot.hs
+++ b/telegram-bot-simple/examples/EchoBot.hs
@@ -49,11 +49,7 @@ handleAction action model = case action of
           , inlineQueryResultInputMessageContent = Just (defaultInputTextMessageContent msg)
           }
         thumbnail = defInlineQueryResultGenericThumbnail result
-        article = InlineQueryResultArticle
-          { inlineQueryResultArticleGeneric = thumbnail
-          , inlineQueryResultArticleUrl = Nothing
-          , inlineQueryResultArticleHideUrl = Nothing
-          }
+        article = defInlineQueryResultArticle thumbnail
         answerInlineQueryRequest = defAnswerInlineQuery queryId [article]
     _ <- runTG  answerInlineQueryRequest
     return ()

--- a/telegram-bot-simple/examples/EchoBot.hs
+++ b/telegram-bot-simple/examples/EchoBot.hs
@@ -44,8 +44,17 @@ updateToAction update _
 handleAction :: Action -> Model -> Eff Action Model
 handleAction action model = case action of
   InlineEcho queryId msg -> model <# do
-    let result = InlineQueryResult InlineQueryResultArticle (InlineQueryResultId msg) (Just msg) (Just (defaultInputTextMessageContent msg)) Nothing
-        answerInlineQueryRequest = defAnswerInlineQuery queryId [result]
+    let result = (defInlineQueryResultGeneric (InlineQueryResultId msg))
+          { inlineQueryResultTitle = Just msg
+          , inlineQueryResultInputMessageContent = Just (defaultInputTextMessageContent msg)
+          }
+        thumbnail = defInlineQueryResultGenericThumbnail result
+        article = InlineQueryResultArticle
+          { inlineQueryResultArticleGeneric = thumbnail
+          , inlineQueryResultArticleUrl = Nothing
+          , inlineQueryResultArticleHideUrl = Nothing
+          }
+        answerInlineQueryRequest = defAnswerInlineQuery queryId [article]
     _ <- runTG  answerInlineQueryRequest
     return ()
   StickerEcho file chat -> model <# do

--- a/telegram-bot-simple/examples/EchoBotWebhook.hs
+++ b/telegram-bot-simple/examples/EchoBotWebhook.hs
@@ -52,8 +52,17 @@ updateToAction update _
 handleAction :: Action -> Model -> Eff Action Model
 handleAction action model = case action of
   InlineEcho queryId msg -> model <# do
-    let result = InlineQueryResult InlineQueryResultArticle (InlineQueryResultId msg) (Just msg) (Just (defaultInputTextMessageContent msg)) Nothing
-        answerInlineQueryRequest = defAnswerInlineQuery queryId [result]
+    let result = (defInlineQueryResultGeneric (InlineQueryResultId msg))
+          { inlineQueryResultTitle = Just msg
+          , inlineQueryResultInputMessageContent = Just (defaultInputTextMessageContent msg)
+          }
+        thumbnail = defInlineQueryResultGenericThumbnail result
+        article = InlineQueryResultArticle
+          { inlineQueryResultArticleGeneric = thumbnail
+          , inlineQueryResultArticleUrl = Nothing
+          , inlineQueryResultArticleHideUrl = Nothing
+          }
+        answerInlineQueryRequest = defAnswerInlineQuery queryId [article]
     _ <- runTG answerInlineQueryRequest
     return ()
   StickerEcho file chat -> model <# do

--- a/telegram-bot-simple/examples/EchoBotWebhook.hs
+++ b/telegram-bot-simple/examples/EchoBotWebhook.hs
@@ -57,11 +57,7 @@ handleAction action model = case action of
           , inlineQueryResultInputMessageContent = Just (defaultInputTextMessageContent msg)
           }
         thumbnail = defInlineQueryResultGenericThumbnail result
-        article = InlineQueryResultArticle
-          { inlineQueryResultArticleGeneric = thumbnail
-          , inlineQueryResultArticleUrl = Nothing
-          , inlineQueryResultArticleHideUrl = Nothing
-          }
+        article = defInlineQueryResultArticle thumbnail
         answerInlineQueryRequest = defAnswerInlineQuery queryId [article]
     _ <- runTG answerInlineQueryRequest
     return ()

--- a/telegram-bot-simple/examples/GameBot.hs
+++ b/telegram-bot-simple/examples/GameBot.hs
@@ -100,14 +100,15 @@ handleAction BotSettings{..} action model = case action of
     return ()
 
   AInlineGame queryId msg -> model <# do
-    let inlineQueryResult =
-          InlineQueryResult
-            InlineQueryResultGame
-            (InlineQueryResultId msg)
-            (Just msg)
-            (Just gameMsg)
-            Nothing
+    let genericResult = (defInlineQueryResultGeneric (InlineQueryResultId msg))
+          { inlineQueryResultTitle = Just msg
+          , inlineQueryResultInputMessageContent = Just gameMsg
+          }
         gameMsg = (defaultInputTextMessageContent gameMessageText) { inputMessageContentParseMode = Just "HTML" }
+        inlineQueryResult = InlineQueryResultGame
+          { inlineQueryResultGameGeneric = genericResult
+          , inlineQueryResultGameGameShortName = gameName
+          }
         answerInlineQueryRequest = defAnswerInlineQuery  queryId [inlineQueryResult]
 
     _ <- runTG answerInlineQueryRequest


### PR DESCRIPTION
Add breaking change for InlineQueryResult to align with Telegram Bot API 6.6 spec.