### PR TITLE
Inline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The supplementary materials for the workshop is available at https://github.com/
 
 ## Examples
 
-See bot examples here: https://github.com/fizruk/telegram-bot-simple/tree/master/examples
+See bot examples here: https://github.com/fizruk/telegram-bot-simple/tree/master/telegram-bot-simple/examples
 
 Use `cabal build all -fexamples` to build it.
 If you are building with stack then use `stack build --flag telegram-bot-simple:examples`.

--- a/telegram-bot-api/src/Telegram/Bot/API/Internal/Utils.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Internal/Utils.hs
@@ -106,8 +106,12 @@ instance (GSomeJSON f, GSomeJSON g) => GSomeJSON (f :+: g) where
     <|> R1 <$> gsomeParseJSON js
 
 addJsonFields :: Value -> [Pair] -> Value
-addJsonFields (Object obj) pairs = Object $  Map.union obj (Map.fromList pairs)
+addJsonFields (Object obj) pairs = Object $  Map.union obj $ Map.fromList (filter (not . isNull) pairs)
 addJsonFields x _ = x
+
+isNull :: Pair -> Bool
+isNull (_, Null) = True
+isNull _ = False
 
 addMultipartFields :: [Input] -> MultipartData tag -> MultipartData tag
 addMultipartFields newFields (MultipartData currenFields files)

--- a/telegram-bot-api/src/Telegram/Bot/API/Types/Chat.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Types/Chat.hs
@@ -57,6 +57,7 @@ data ChatType
   | ChatTypeGroup
   | ChatTypeSupergroup
   | ChatTypeChannel
+  | ChatTypeSender
   deriving (Generic, Show)
 
 instance ToJSON   ChatType where

--- a/telegram-bot-simple/README.md
+++ b/telegram-bot-simple/README.md
@@ -13,7 +13,7 @@ The supplementary materials for the workshop is available at https://github.com/
 
 ## Examples
 
-See bot examples here: https://github.com/fizruk/telegram-bot-simple/tree/master/examples
+See bot examples here: https://github.com/fizruk/telegram-bot-simple/tree/master/telegram-bot-simple/examples
 
 Use `cabal build all -fexamples` to build it.
 If you are building with stack then use `stack build --flag telegram-bot-simple:examples`.


### PR DESCRIPTION
1. Fixes link in README
2. Fixes `inlineQueryChatType` to support `sender` type (#156)
3. Removes Null values for Json while adding Json fields with addJsonFields function (#156). Although it doesn't seem like a good idea :) Maybe it's better to handle `Maybe` somewhere closer to `toJSON`. For each field independently, somewhere along the lines of `[ "normal_field" .= normal_field ]  ++ maybe [] (\value -> ["maybe_field" .= value]) maybe_field`