### PR TITLE
Support Bot API 6.9

### DIFF
--- a/telegram-bot-api/src/Telegram/Bot/API/Methods/PromoteChatMember.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Methods/PromoteChatMember.hs
@@ -32,6 +32,9 @@ data PromoteChatMemberRequest = PromoteChatMemberRequest
   , promoteChatMemberCanChangeInfo :: Maybe Bool -- ^ Pass 'True', if the administrator can change chat title, photo and other settings.
   , promoteChatMemberCanInviteUsers :: Maybe Bool -- ^ Pass 'True', if the administrator can invite new users to the chat.
   , promoteChatMemberCanPinMessages :: Maybe Bool -- ^ Pass 'True', if the administrator can pin messages, supergroups only.
+  , promoteChatMemberCanPostStories :: Maybe Bool -- ^ Pass 'True' if the administrator can post stories in the channel; channels only.
+  , promoteChatMemberCanEditStories :: Maybe Bool -- ^ Pass 'True' if the administrator can edit stories posted by other users; channels only.
+  , promoteChatMemberCanDeleteStories :: Maybe Bool -- ^ Pass 'True' if the administrator can delete stories posted by other users; channels only.
   , promoteChatMemberCanManageTopics :: Maybe Bool -- ^ Pass 'True', if the user is allowed to create, rename, close, and reopen forum topics, supergroups only.
   }
   deriving Generic

--- a/telegram-bot-api/src/Telegram/Bot/API/Types/ChatAdministratorRights.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Types/ChatAdministratorRights.hs
@@ -21,6 +21,9 @@ data ChatAdministratorRights = ChatAdministratorRights
   , chatAdministratorRightsCanPostMessages     :: Maybe Bool -- ^ 'True', if the administrator can post in the channel; channels only.
   , chatAdministratorRightsCanEditMessages     :: Maybe Bool -- ^ 'True', if the administrator can edit messages of other users and can pin messages; channels only.
   , chatAdministratorRightsCanPinMessages      :: Maybe Bool -- ^ 'True', if the user is allowed to pin messages; groups and supergroups only
+  , chatAdministratorRightsCanPostStories      :: Maybe Bool -- ^ 'True', if the administrator can post stories in the channel; channels only.
+  , chatAdministratorRightsCanEditStories      :: Maybe Bool -- ^ 'True', if the administrator can edit stories posted by other users; channels only.
+  , chatAdministratorRightsCanDeleteStories    :: Maybe Bool -- ^ 'True', if the administrator can delete stories posted by other users; channels only.
   , chatAdministratorRightsCanManageTopics     :: Maybe Bool -- ^ 'True', if the user is allowed to create, rename, close, and reopen forum topics; supergroups only.
   }
   deriving (Generic, Show)

--- a/telegram-bot-api/src/Telegram/Bot/API/Types/ChatMember.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Types/ChatMember.hs
@@ -33,6 +33,9 @@ data ChatMember = ChatMember
   , chatMemberCanChangeInfo         :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can change the chat title, photo and other settings.
   , chatMemberCanPostMessages       :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can post in the channel, channels only.
   , chatMemberCanEditMessages       :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can edit messages of other users and can pin messages, channels only.
+  , chatMemberCanPostStories        :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can post stories in the channel; channels only.
+  , chatMemberCanEditStories        :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can edit stories posted by other users; channels only.
+  , chatMemberCanDeleteStories        :: Maybe Bool -- ^ Administrators only. 'True', if the administrator can delete stories posted by other users; channels only.
 
   -- administrator, restricted
   , chatMemberCanInviteUsers        :: Maybe Bool -- ^ Administrators and restricted only. 'True', if the administrator can invite new users to the chat.

--- a/telegram-bot-api/src/Telegram/Bot/API/Types/WriteAccessAllowed.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Types/WriteAccessAllowed.hs
@@ -10,8 +10,10 @@ import Telegram.Bot.API.Internal.Utils
 -- ** 'WriteAccessAllowed'
 
 -- | This object represents a service message about a user allowing a bot added to the attachment menu to write messages. Currently holds no information.
-newtype WriteAccessAllowed = WriteAccessAllowed
-  { writeAccessAllowedWebAppName :: Maybe Text -- ^ Name of the Web App which was launched from a link.
+data WriteAccessAllowed = WriteAccessAllowed
+  { writeAccessAllowedFromRequest :: Maybe Bool -- ^ True, if the access was granted after the user accepted an explicit request from a Web App sent by the method 'requestWriteAccess'.
+  , writeAccessAllowedWebAppName :: Maybe Text -- ^ Name of the Web App which was launched from a link.
+  , writeAccessAllowedFromAttachmentMenu :: Maybe Bool -- ^ 'True', if the access was granted when the bot was added to the attachment or side menu.
   }
   deriving (Generic, Show)
 


### PR DESCRIPTION
Closes #161.

Modified Types:
- `ChatMember`
- `ChatAdministratorRights`
- `WriteAccessAllowed`

Modified Methods:
- `promoteChatMember`

NB. WebApp / Mini Apps API was not covered by this library at all. Therefore, corresponding changes were not covered by this MR. Separate issue #167 created to track it.