### PR TITLE
Add functor instance to Response

### DIFF
--- a/telegram-bot-api/src/Telegram/Bot/API/MakingRequests.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/MakingRequests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
@@ -58,7 +59,7 @@ data Response a = Response
   , responseResult      :: a
   , responseErrorCode   :: Maybe Integer
   , responseParameters  :: Maybe ResponseParameters
-  } deriving (Show, Generic)
+  } deriving (Show, Generic, Functor)
 
 instance ToJSON   a => ToJSON   (Response a) where toJSON = gtoJSON
 instance FromJSON a => FromJSON (Response a) where parseJSON = gparseJSON


### PR DESCRIPTION
The `Response` type currently doesn't have a functor instance. It would spare me writing some boilerplate code if it did.

*Not* having a functor instance doesn't serve any purpose since the constructor of `Response` is exported and anyone can make their own `Response` mapping function, so I can't see any reason not to add this instance.