### PR TITLE
Ignore updates that produce parse failures

### DIFF
--- a/telegram-bot-api/src/Telegram/Bot/API/GettingUpdates.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/GettingUpdates.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TypeOperators              #-}
 module Telegram.Bot.API.GettingUpdates where
 
-import           Data.Aeson                      (FromJSON (..), ToJSON (..))
+import           Data.Aeson                      (FromJSON (..), ToJSON (..), Value)
 import           Data.Foldable                   (asum)
 import           Data.Proxy
 import           GHC.Generics                    (Generic)
@@ -70,8 +70,10 @@ extractUpdateMessage Update{..} = asum
 
 -- ** 'getUpdates'
 
-type GetUpdates
-  = "getUpdates" :> ReqBody '[JSON] GetUpdatesRequest :> Get '[JSON] (Response [Update])
+type GetUpdatesAs a
+  = "getUpdates" :> ReqBody '[JSON] GetUpdatesRequest :> Get '[JSON] (Response [a])
+
+type GetUpdates = GetUpdatesAs Update
 
 -- | Use this method to receive incoming updates using long polling.
 -- An list of 'Update' objects is returned.
@@ -81,6 +83,14 @@ type GetUpdates
 -- NOTE: In order to avoid getting duplicate updates, recalculate offset after each server response.
 getUpdates :: GetUpdatesRequest -> ClientM (Response [Update])
 getUpdates = client (Proxy @GetUpdates)
+
+-- | More liberal version of `getUpdates` funcion.
+--
+-- It's useful  when you aren't sure that you can
+-- parse all the types of updates, so you would recieve
+-- a list of Value with updates, that you can parse later.
+getUpdatesAsValue :: GetUpdatesRequest -> ClientM (Response [Value])
+getUpdatesAsValue = client (Proxy @(GetUpdatesAs Value))
 
 -- | Request parameters for 'getUpdates'.
 data GetUpdatesRequest = GetUpdatesRequest


### PR DESCRIPTION
I implemented updates fetching as a list of `Value`, so that allow us to receive some of the updates even if the others can't be parsed due to API changes. Tested on github.com/s-and-witch/playground-hs, here is an example of error message:
> Failed to parse an update! Please, make sure you have the latest version of `telegram-bot-api` library and consider opening an issue if so. Error message: Error in $.message.entities[0].type: parsing Telegram.Bot.API.Types.MessageEntity.MessageEntityType failed, expected one of the tags ["mention","hashtag","bot_command","url","email","bold","italic","underline","strikethrough","code","pre","text_link","text_mention","cashtag","phone_number","spoiler","custom_emoji"], but found tag "blockquote"
