### PR TITLE
Fix `message_thread_id` field for `copyMessage`, `copyMessages`

### DIFF
--- a/telegram-bot-api/src/Telegram/Bot/API/Methods/CopyMessage.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Methods/CopyMessage.hs
@@ -36,7 +36,7 @@ copyMessage = client (Proxy @CopyMessage)
 -- | Request parameters for 'copyMessage'.
 data CopyMessageRequest = CopyMessageRequest
   { copyMessageChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , copyMessageMessageThreadId :: Maybe Message -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , copyMessageMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
   , copyMessageFromChatId :: SomeChatId -- ^ Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
   , copyMessageMessageId :: MessageId -- ^ Message identifier in the chat specified in from_chat_id
   , copyMessageCaption :: Maybe Text -- ^ New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept

--- a/telegram-bot-api/src/Telegram/Bot/API/Methods/CopyMessages.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Methods/CopyMessages.hs
@@ -39,7 +39,7 @@ copyMessages = client (Proxy @CopyMessages)
 -- | Request parameters for 'copyMessages'.
 data CopyMessagesRequest = CopyMessagesRequest
   { copyMessagesChatId :: SomeChatId -- ^ Unique identifier for the target chat or username of the target channel (in the format @channelusername).
-  , copyMessagesMessageThreadId :: Maybe Message -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+  , copyMessagesMessageThreadId :: Maybe MessageThreadId -- ^ Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
   , copyMessagesFromChatId :: SomeChatId -- ^ Unique identifier for the chat where the original message was sent (or channel username in the format \@channelusername).
   , copyMessagesMessageIds :: [MessageId] -- ^ Identifiers of 1-100 messages in the chat @from_chat_id@ to copy. The identifiers must be specified in a strictly increasing order.
   , copyMessagesCaption :: Maybe Text -- ^ New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept


### PR DESCRIPTION
Fix `message_thread_id` field for `copyMessage`, `copyMessages`.