### PR TITLE
Change user_id to users in UsersShared

### DIFF
--- a/telegram-bot-api/src/Telegram/Bot/API/Types/UsersShared.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Types/UsersShared.hs
@@ -13,7 +13,7 @@ import Telegram.Bot.API.Internal.Utils
 -- | This object contains information about the users whose identifiers were shared with the bot using a 'KeyboardButtonRequestUsers' button.
 data UsersShared = UsersShared
   { usersSharedRequestId :: RequestId -- ^ Identifier of the request.
-  , usersSharedUserId :: [SharedUser] -- ^ Information about users shared with the bot.
+  , usersSharedUsers :: [SharedUser] -- ^ Information about users shared with the bot.
   }
   deriving (Generic, Show)
 


### PR DESCRIPTION
The field containing shared users in UsersShared was `user_id`, while in the most up-to-date Bot API it's `users`.  

![image](https://github.com/user-attachments/assets/0375d132-c37f-4f9d-ada7-3ef1a8a2273d)
