### PR TITLE
fix incorrect WebAppInfo encoding

### DIFF
--- a/telegram-bot-api/src/Telegram/Bot/API/Types/Common.hs
+++ b/telegram-bot-api/src/Telegram/Bot/API/Types/Common.hs
@@ -75,8 +75,11 @@ newtype PollId = PollId Text
 newtype ShippingOptionId = ShippingOptionId Text
   deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
-newtype WebAppInfo = WebAppInfo { webAppInfoUrl :: Text }
-  deriving (Generic, Show, ToJSON, FromJSON)
+data WebAppInfo = WebAppInfo { webAppInfoUrl :: Text }
+  deriving (Generic, Show)
+
+instance ToJSON WebAppInfo where toJSON = gtoJSON
+instance FromJSON WebAppInfo where parseJSON = gparseJSON
 
 newtype CallbackQueryId = CallbackQueryId Text
   deriving (Eq, Show, Generic, ToJSON, FromJSON)


### PR DESCRIPTION
`newtype` unpacks the data and encodes this type as a string, instead of encoding it as an object with one field "url" (https://core.telegram.org/bots/api#webappinfo).